### PR TITLE
Redirect upgrade path directly to weFormsPro.com in Form Editor UI

### DIFF
--- a/includes/admin/class-form-builder-assets.php
+++ b/includes/admin/class-form-builder-assets.php
@@ -124,7 +124,7 @@ class WeForms_Form_Builder_Assets {
      * @return string
      */
     public static function get_pro_url() {
-        $link = 'https://wedevs.com/weforms-upgrade/';
+        $link = 'https://weformspro.com/';
 
         if ( $aff = get_option( '_weforms_aff_ref' ) ) {
             $link = add_query_arg( [ 'ref' => $aff ], $link );


### PR DESCRIPTION
The Upgrade Path now directly goes to weFormsPro.com instead of going to wedevs.com and then redirecting