### PR TITLE
Fix admin notice for import showing a gettext placeholder. Fixes #6

### DIFF
--- a/includes/importer/class-importer-abstract.php
+++ b/includes/importer/class-importer-abstract.php
@@ -149,7 +149,7 @@ abstract class WeForms_Importer_Abstract {
             return;
         } ?>
         <div class="notice notice-info">
-            <p><strong><?php printf( esc_html_e( '%s Detected', 'weforms' ), wp_kses_post( $this->get_importer_name() ) ); ?></strong></p>
+            <p><strong><?php printf( esc_html__( '%s Detected', 'weforms' ), wp_kses_post( $this->get_importer_name() ) ); ?></strong></p>
             <p><?php printf( wp_kses_post( 'Hey, looks like you have <strong>%s</strong> installed. Would you like to <strong>import</strong> the forms into weForms?', 'weforms' ), wp_kses_post ( $this->get_importer_name() ) ); ?></p>
 
             <p>


### PR DESCRIPTION
To test, login to the admin area and make sure ninja or any other form plugin is installed that is compatible. Admin notice should appear with the correct plugin being detected.