### PR TITLE
Google Maps in Email will show Address. Fixes #45

### DIFF
--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -648,7 +648,7 @@ class WeForms_Notification {
             $table .= '<tr class="field-value">';
             $table .= '<td>';
 
-            if ( in_array( $value['type'], [ 'multiple_select', 'checkbox_field' ] ) ) {
+            if ( in_array( $value['type'], [ 'multiple_select', 'checkbox_field', 'google_maps' ] ) ) {
                 $field_value = is_array( $field_value ) ? $field_value : [];
 
                 if ( $field_value ) {
@@ -661,6 +661,8 @@ class WeForms_Notification {
                 } else {
                     $table .= '&mdash;';
                 }
+            }elseif (in_array( $value['type'], [ 'google_map' ] ) ) {
+                $table .= $field_value['address'];    
             } else {
                 $table .= $field_value;
             }

--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -648,7 +648,7 @@ class WeForms_Notification {
             $table .= '<tr class="field-value">';
             $table .= '<td>';
 
-            if ( in_array( $value['type'], [ 'multiple_select', 'checkbox_field', 'google_maps' ] ) ) {
+            if ( in_array( $value['type'], array( 'multiple_select', 'checkbox_field' ) ) ) {
                 $field_value = is_array( $field_value ) ? $field_value : [];
 
                 if ( $field_value ) {
@@ -661,7 +661,7 @@ class WeForms_Notification {
                 } else {
                     $table .= '&mdash;';
                 }
-            }elseif (in_array( $value['type'], [ 'google_map' ] ) ) {
+            }elseif ( in_array( $value['type'], array('google_map') ) ) {
                 $table .= $field_value['address'];    
             } else {
                 $table .= $field_value;

--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -661,7 +661,7 @@ class WeForms_Notification {
                 } else {
                     $table .= '&mdash;';
                 }
-            }elseif ( in_array( $value['type'], array('google_map') ) ) {
+            } elseif ( in_array( $value['type'], array( 'google_map' ) ) ) {
                 $table .= $field_value['address'];    
             } else {
                 $table .= $field_value;


### PR DESCRIPTION
Email notification sends the array of data for Google Maps integration. Fixed to send the address from the google maps data. Currently, there is no way to add the map to an email. 

We could use the Map Static API in future enhancements, but this will need more testing and research.

Or we can have the google maps section of the email have a link to the entry within weforms.