### PR TITLE
Uses Vue.js minified file Fixes #38

### DIFF
--- a/assets/js/utils/vendor-assets.js
+++ b/assets/js/utils/vendor-assets.js
@@ -3,7 +3,7 @@
  */
 
 module.exports = [
-    'assets/wpuf/vendor/vue/vue.js',
+    'assets/wpuf/vendor/vue/vue.min.js',
     'assets/wpuf/vendor/vuex/vuex.js',
     'assets/js/vendor/vue-router.js',
     'assets/js/vendor/nprogress.js',


### PR DESCRIPTION
Uses vue.min.js for production rather than vue.js. Fixes console message about using Vue in development mode.