### PR TITLE
Update to Sprout invoices integration fixes #112

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -176,11 +176,7 @@ function weforms_get_entry_payment( $entry_id ) {
 
     $query = 'SELECT transaction_id FROM ' . $wpdb->prefix . 'weforms_payments' .
         ' WHERE entry_id = ' . $entry_id;
-        error_log(print_r($query,1));
-
     $payment = $wpdb->get_row( $query, $entry_id );
-    error_log(print_r($payment,1));
-
     
     return $payment;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -165,6 +165,27 @@ function weforms_get_form_payments( $form_id, $args = [] ) {
 }
 
 /**
+ * Get payments by a entry_id
+ *
+ * @param int   $entry_id
+ *
+ * @return object
+ */
+function weforms_get_entry_payment( $entry_id ) {
+    global $wpdb;
+
+    $query = 'SELECT transaction_id FROM ' . $wpdb->prefix . 'weforms_payments' .
+        ' WHERE entry_id = ' . $entry_id;
+        error_log(print_r($query,1));
+
+    $payment = $wpdb->get_row( $query, $entry_id );
+    error_log(print_r($payment,1));
+
+    
+    return $payment;
+}
+
+/**
  * Get an entry by id
  *
  * @param int $entry_id

--- a/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
+++ b/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
@@ -105,10 +105,10 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
         
         preg_match_all("/(?<=:)\w+(?=\})/", $integration->fields->line_items, $matches );
 
-        $test_logic = array_key_exists( $matches[0][0], $form_data['data'] );
+        $line_item_data = array_key_exists( $matches[0][0], $form_data['data'] );
 
         // bail out if nothing found to be replaced
-        if ( $test_logic ) {
+        if ( $line_item_data ) {
 
             $li = " ";
 

--- a/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
+++ b/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
@@ -365,6 +365,8 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
          */
         $invoice_id = SI_Invoice::create_invoice( $invoice_args );
         $invoice = SI_Invoice::get_instance( $invoice_id );
+        $status = SI_Payment::STATUS_AUTHORIZED;
+        $invoice_status = SI_Payment::set_status($status);
         
         $invoice->set_line_items( $submission['line_items'] );
         $invoice->set_calculated_total();

--- a/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
+++ b/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
@@ -95,12 +95,17 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
         }
 
         preg_match( '/{field:(\w*)}/', $integration->fields->line_items, $match );
+        //$req_match = $_REQUEST[$match[1]];
+        //error_log("match-request" . " = " . print_r($req_match,1));
+        //error_log("match" . " = " . print_r($match[1],1));
 
         // bail out if nothing found to be replaced
         if (isset( $match[1] ) && isset( $_REQUEST[$match[1]] )) {
 
             $fieldSlug = $match[1];
-            $lineItemsSelected = $_REQUEST[$match[1]];
+            $lineItemsSelected = is_array( $_REQUEST[$match[1]] ) ? $_REQUEST[$match[1]] : array($_REQUEST[$match[1]]);
+        
+            //error_log("line Items" . " = " . print_r($lineItemsSelected,1));
 
             // was anything even selected?
             if (is_array( $lineItemsSelected )) {
@@ -109,6 +114,7 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
                 $lineItemOptions = false;
                 foreach ($form_fields as $key => $field) {
                     if ($field['name'] === $fieldSlug) {
+                        //error_log("form-fields" . " = " . print_r($field,1));
                         $lineItemOptions = ( array( $field['options'] ) ) ? $field['options'] : false;
                     }
                 }
@@ -124,6 +130,13 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
                             'qty' => 1,
                         );
                     }
+                } else {
+                    $li[] = array(
+                        'desc' => $lineItemsSelected['name'],
+                        'rate' => $lineItemsSelected['price'],
+                        'total' => $lineItemsSelected['price'],
+                        'qty' => $lineItemsSelected['quantity'],
+                    );
                 }
             }
 
@@ -328,7 +341,7 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
 
     protected function create_invoice($submission = array())
     {
-
+        //error_log("Invoice-Data" . " = " . print_r($submission,1));
         $invoice_args = array(
             'subject' => sprintf( apply_filters( 'si_form_submission_title_format', '%1$s (%2$s)', $submission ), $submission['subject'], $submission['client_name'] ),
             'fields' => $submission,
@@ -337,6 +350,7 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
 
         do_action( 'si_doc_generation_start' );
 
+        //error_log("Invoice-Data" . " = " . print_r($invoice_args,1));
         /**
          * Creates the invoice from the arguments
          */

--- a/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
+++ b/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
@@ -84,13 +84,7 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
             return;
         }
 
-        // $form_payment_data = weforms_get_form_payments( $form_id );
-
-        // error_log("Form Payment Data" . " = " . print_r($form_payment_data,1));
-
         $payment_data = weforms_get_entry_payment( $entry_id );
-
-        error_log( $payment_data );
 
         $address = self::get_value( $integration->fields->address, $entry_id, $form_id, $page_id );
         if (is_array( $address )) {

--- a/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
+++ b/includes/integrations/sprout-invoices/class-integration-sprout-invoices.php
@@ -30,7 +30,7 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
                 'duedate' => '',
                 'number' => '',
                 'vat' => '',
-                'line_items' => ''
+                'line_items' => '',
             ],
         ];
 
@@ -83,6 +83,15 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
         if (false === $form_data) {
             return;
         }
+
+        // $form_payment_data = weforms_get_form_payments( $form_id );
+
+        // error_log("Form Payment Data" . " = " . print_r($form_payment_data,1));
+
+        $payment_data = weforms_get_entry_payment( $entry_id );
+
+        error_log( $payment_data );
+
         $address = self::get_value( $integration->fields->address, $entry_id, $form_id, $page_id );
         if (is_array( $address )) {
             $full_address = array(
@@ -93,73 +102,74 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
                 'country' => isset( $address['country_select'] ) ? $address['country_select'] : '',
             );
         }
+        
+        preg_match_all("/(?<=:)\w+(?=\})/", $integration->fields->line_items, $matches );
 
-        preg_match( '/{field:(\w*)}/', $integration->fields->line_items, $match );
-        //$req_match = $_REQUEST[$match[1]];
-        //error_log("match-request" . " = " . print_r($req_match,1));
-        //error_log("match" . " = " . print_r($match[1],1));
+        $test_logic = array_key_exists( $matches[0][0], $form_data['data'] );
 
         // bail out if nothing found to be replaced
-        if (isset( $match[1] ) && isset( $_REQUEST[$match[1]] )) {
+        if ( $test_logic ) {
 
-            $fieldSlug = $match[1];
-            $lineItemsSelected = is_array( $_REQUEST[$match[1]] ) ? $_REQUEST[$match[1]] : array($_REQUEST[$match[1]]);
-        
-            //error_log("line Items" . " = " . print_r($lineItemsSelected,1));
+            $li = " ";
 
-            // was anything even selected?
-            if (is_array( $lineItemsSelected )) {
-
+            foreach($matches[0] as $fieldSlug ){
                 $form_fields = weforms()->form->get( $form_id )->get_fields();
-                $lineItemOptions = false;
                 foreach ($form_fields as $key => $field) {
                     if ($field['name'] === $fieldSlug) {
-                        //error_log("form-fields" . " = " . print_r($field,1));
-                        $lineItemOptions = ( array( $field['options'] ) ) ? $field['options'] : false;
+                        $lineItemOptions = array_key_exists( 'options', $field ) ? $field['options'] : 'false';
                     }
                 }
-
-                // if the options are found
-                if ($lineItemOptions) {
-                    $li = array();
-                    foreach ($lineItemsSelected as $rate) {
-                        $li[] = array(
-                            'desc' => $lineItemOptions[$rate],
-                            'rate' => $rate,
-                            'total' => $rate,
+                $lineItemsSelected = array($form_data['data'][$fieldSlug]);
+                if ($lineItemOptions != 'false') {
+                    $li_items = array();
+                    foreach ($lineItemsSelected as $item) {
+                        $li_items[] = array(
+                            'desc' => $item,
+                            'rate' => array_search($item, $lineItemOptions),
+                            'total' => array_search($item, $lineItemOptions),
                             'qty' => 1,
                         );
                     }
                 } else {
-                    $li[] = array(
-                        'desc' => $lineItemsSelected['name'],
-                        'rate' => $lineItemsSelected['price'],
-                        'total' => $lineItemsSelected['price'],
-                        'qty' => $lineItemsSelected['quantity'],
+                    $li_deposit[] = array(
+                        'desc' => $lineItemsSelected[0]['product'],
+                        'rate' => $lineItemsSelected[0]['price'],
+                        'total' => $lineItemsSelected[0]['price'],
+                        'qty' => $lineItemsSelected[0]['quantity'],
                     );
                 }
+                
+            };
+            if ( isset( $li_items ) && isset( $li_deposit ) ) {
+                $li = array_merge( $li_items, $li_deposit );
+            } elseif ( isset( $li_items ) ) {
+                $li = $li_items;
+            } else {
+                $li = $li_deposit;
             }
-
         }
+
+
 
         //Setting up array to send user info to WordPress
         $submission = array(
-            'subject' => self::get_value( $integration->fields->subject, $entry_id, $form_id, $page_id ),
-            'line_items' => !empty( $li ) ? $li : array(),
+            'subject'      => self::get_value( $integration->fields->subject, $entry_id, $form_id, $page_id ),
+            'line_items'   => !empty( $li ) ? $li : array(),
             'full_address' => !empty( $full_address ) ? $full_address : array(),
-            'client_name' => self::get_value( $integration->fields->client_name, $entry_id, $form_id, $page_id ),
-            'email' => self::get_value( $integration->fields->email, $entry_id, $form_id, $page_id ),
-            'first_name' => self::get_value( $integration->fields->first_name, $entry_id, $form_id, $page_id ),
-            'last_name' => self::get_value( $integration->fields->last_name, $entry_id, $form_id, $page_id ),
-            'notes' => self::get_value( $integration->fields->notes, $entry_id, $form_id, $page_id ),
-            'duedate' => self::get_value( $integration->fields->duedate, $entry_id, $form_id, $page_id ),
-            'number' => self::get_value( $integration->fields->number, $entry_id, $form_id, $page_id ),
-            'vat' => self::get_value( $integration->fields->vat, $entry_id, $form_id, $page_id ),
-            'entry_note' => self::build_entry_note( $form_id, $entry_id ),
-            'entry_id' => $entry_id,
-            'form_id' => $form_id,
-            'page_id' => $page_id,
-            'form_data' => $form_data['data'],
+            'client_name'  => self::get_value( $integration->fields->client_name, $entry_id, $form_id, $page_id ),
+            'email'        => self::get_value( $integration->fields->email, $entry_id, $form_id, $page_id ),
+            'first_name'   => self::get_value( $integration->fields->first_name, $entry_id, $form_id, $page_id ),
+            'last_name'    => self::get_value( $integration->fields->last_name, $entry_id, $form_id, $page_id ),
+            'notes'        => self::get_value( $integration->fields->notes, $entry_id, $form_id, $page_id ),
+            'duedate'      => self::get_value( $integration->fields->duedate, $entry_id, $form_id, $page_id ),
+            'number'       => self::get_value( $integration->fields->number, $entry_id, $form_id, $page_id ),
+            'vat'          => self::get_value( $integration->fields->vat, $entry_id, $form_id, $page_id ),
+            'entry_note'   => self::build_entry_note( $form_id, $entry_id ),
+            'entry_id'     => $entry_id,
+            'payment'      => !empty( $li_deposit ) ? 'true' : 'false',
+            'form_id'      => $form_id,
+            'page_id'      => $page_id,
+            'form_data'    => $form_data['data'],
         );
         $submission = apply_filters('wpf_si_submission_data_for_creation', $submission );
 
@@ -290,6 +300,7 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
             return '';
         }
 
+        $table = ' ';
         $table .= '<div class="submission-values">';
         $table .= '<ul>';
 
@@ -341,7 +352,6 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
 
     protected function create_invoice($submission = array())
     {
-        //error_log("Invoice-Data" . " = " . print_r($submission,1));
         $invoice_args = array(
             'subject' => sprintf( apply_filters( 'si_form_submission_title_format', '%1$s (%2$s)', $submission ), $submission['subject'], $submission['client_name'] ),
             'fields' => $submission,
@@ -350,13 +360,12 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
 
         do_action( 'si_doc_generation_start' );
 
-        //error_log("Invoice-Data" . " = " . print_r($invoice_args,1));
         /**
          * Creates the invoice from the arguments
          */
         $invoice_id = SI_Invoice::create_invoice( $invoice_args );
         $invoice = SI_Invoice::get_instance( $invoice_id );
-
+        
         $invoice->set_line_items( $submission['line_items'] );
         $invoice->set_calculated_total();
 
@@ -371,6 +380,11 @@ class WeForms_Integration_SI extends WeForms_Abstract_Integration
 
         if (isset( $submission['duedate'] )) {
             $invoice->set_due_date( $submission['duedate'] );
+        }
+
+        // Add Payment from weForms if deposit
+        if ( $submission['payment'] === 'false' ) {
+            SI_PAYMENT::new_payment();
         }
 
         // Finally associate the doc with the form submission


### PR DESCRIPTION
Updated Sprout invoices integration to allow single product, multi product, checkbox. and radio to convert to line items.

Added the payment status to be passed to created invoices. 

Elana has tested this, just need a code review.