### PR TITLE
Mail Poet Integration

### DIFF
--- a/includes/integrations/mailpoet/component/template.php
+++ b/includes/integrations/mailpoet/component/template.php
@@ -1,5 +1,5 @@
 <div>
-    <?php if ( class_exists( 'WYSIJA' ) ) { ?>
+    <?php if ( class_exists(\MailPoet\API\API::class)) { ?>
     <div class="wpuf-int-form-row">
         <div class="wpuf-int-field-label">
             <label for="mailpoet-list-id"><?php esc_html_e( 'List', 'weforms' ); ?></label>
@@ -7,7 +7,7 @@
         <div class="wpuf-int-field">
             <select v-model="settings.list" id="mailpoet-list-id">
                 <option value=""><?php esc_html_e( '&mdash; Select List &mdash;', 'weforms' ); ?></option>
-                <option v-for="list in lists" :value="list.list_id">{{ list.name }}</option>
+                <option v-for="list in lists" :value="list.id">{{ list.name }}</option>
             </select>
 
             <span class="description"><?php esc_html_e( 'Select your mailpoet list for subscription', 'weforms' ); ?></span>


### PR DESCRIPTION
https://github.com/BoldGrid/weforms-pro/issues/75

@avonville I can't get the Subscriber information to work not sure if it's a JavaScript issue or something in VUE. 

If you comment this out from class-integration-mailpoet.php everything works on the form. 

  $get_subscriber = $mailpoet->getSubscriber($subscriber['email']);
        if (!$get_subscriber) {
            // Subscriber doesn't exist let's create one
             $mailpoet_api->addSubscriber($subscriber['email'], '');
        }else{
            // In case subscriber exists just add them to new lists
            $mailpoet_api->subscribeToLists($subscriber['email'], $subscriber['list_ids'] );
        } 
        
        
        

Array passes fine but something with the subscriber list isn't working. 
![image](https://user-images.githubusercontent.com/5271694/135872494-8fa4d235-689b-4672-875c-bab83b56b3f7.png)

This did change in the template.php but list_id doesn't exist in the updated MailPoet its just ID
 <option v-for="list in lists" :value="list.list_id">{{ list.name }}</option>

