### PR TITLE
fixes #153

### DIFF
--- a/assets/js-templates/spa-components.php
+++ b/assets/js-templates/spa-components.php
@@ -1035,7 +1035,7 @@
 
         <p><?php esc_html_e( 'Our EXPERT Support Team is always ready to Help you out.', 'weforms' ); ?></p>
 
-        <a target="_blank" class="button button-primary" href="https://weformspro.com/support/?utm_source=weforms-help-page&utm_medium=help-block&utm_campaign=need-assistance"><?php esc_html_e( 'Contact Support', 'weforms' ); ?></a>
+        <a target="_blank" class="button button-primary" href="<?php echo class_exists( 'WeForms_Pro' ) ? esc_url( 'https://weformspro.com/account/premium-support/' ) : esc_url( 'https://wordpress.org/support/plugin/weforms/' );?>"><?php esc_html_e( 'Contact Support', 'weforms' ); ?></a>
     </div>
 
     <div class="help-block">


### PR DESCRIPTION
Adds logic to support links and adds correct links. Fixes #153 

To Test: 
Go to the help tab from the settings menu on the left.
Click the  Support link
If you have pro enabled it will go to https://weformspro.com/account/premium-support/.
Disable pro and it will take you to https://wordpress.org/support/plugin/weforms/.