### PR TITLE
fixes #89

### DIFF
--- a/assets/js/vendor.js
+++ b/assets/js/vendor.js
@@ -3627,7 +3627,7 @@ return VueRouter;
 		}
 	});
 
-	/* 
+	/*
 	* Timepicker manager.
 	* Use the singleton instance of this class, $.timepicker, to interact with the time picker.
 	* Settings for (groups of) time pickers are maintained in an instance object,
@@ -3738,7 +3738,7 @@ return VueRouter;
 		units: ['hour','minute','second','millisec'],
 		control: null,
 
-		/* 
+		/*
 		* Override the default settings for all instances of the time picker.
 		* @param  settings  object - the new settings to use as defaults (anonymous object)
 		* @return the manager object
@@ -3815,13 +3815,13 @@ return VueRouter;
 				tp_inst.control = tp_inst._controls[tp_inst._defaults.controlType];
 			}
 			// controlType is an object and must implement create, options, value methods
-			else{ 
+			else{
 				tp_inst.control = tp_inst._defaults.controlType;
 			}
 
 			if (tp_inst._defaults.timezoneList === null) {
-				var timezoneList = ['-1200', '-1100', '-1000', '-0930', '-0900', '-0800', '-0700', '-0600', '-0500', '-0430', '-0400', '-0330', '-0300', '-0200', '-0100', '+0000', 
-									'+0100', '+0200', '+0300', '+0330', '+0400', '+0430', '+0500', '+0530', '+0545', '+0600', '+0630', '+0700', '+0800', '+0845', '+0900', '+0930', 
+				var timezoneList = ['-1200', '-1100', '-1000', '-0930', '-0900', '-0800', '-0700', '-0600', '-0500', '-0430', '-0400', '-0330', '-0300', '-0200', '-0100', '+0000',
+									'+0100', '+0200', '+0300', '+0330', '+0400', '+0430', '+0500', '+0530', '+0545', '+0600', '+0630', '+0700', '+0800', '+0845', '+0900', '+0930',
 									'+1000', '+1030', '+1100', '+1130', '+1200', '+1245', '+1300', '+1400'];
 
 				if (tp_inst._defaults.timezoneIso8601) {
@@ -3833,13 +3833,13 @@ return VueRouter;
 			}
 
 			tp_inst.timezone = tp_inst._defaults.timezone;
-			tp_inst.hour = tp_inst._defaults.hour < tp_inst._defaults.hourMin? tp_inst._defaults.hourMin : 
+			tp_inst.hour = tp_inst._defaults.hour < tp_inst._defaults.hourMin? tp_inst._defaults.hourMin :
 							tp_inst._defaults.hour > tp_inst._defaults.hourMax? tp_inst._defaults.hourMax : tp_inst._defaults.hour;
-			tp_inst.minute = tp_inst._defaults.minute < tp_inst._defaults.minuteMin? tp_inst._defaults.minuteMin : 
+			tp_inst.minute = tp_inst._defaults.minute < tp_inst._defaults.minuteMin? tp_inst._defaults.minuteMin :
 							tp_inst._defaults.minute > tp_inst._defaults.minuteMax? tp_inst._defaults.minuteMax : tp_inst._defaults.minute;
-			tp_inst.second = tp_inst._defaults.second < tp_inst._defaults.secondMin? tp_inst._defaults.secondMin : 
+			tp_inst.second = tp_inst._defaults.second < tp_inst._defaults.secondMin? tp_inst._defaults.secondMin :
 							tp_inst._defaults.second > tp_inst._defaults.secondMax? tp_inst._defaults.secondMax : tp_inst._defaults.second;
-			tp_inst.millisec = tp_inst._defaults.millisec < tp_inst._defaults.millisecMin? tp_inst._defaults.millisecMin : 
+			tp_inst.millisec = tp_inst._defaults.millisec < tp_inst._defaults.millisecMin? tp_inst._defaults.millisecMin :
 							tp_inst._defaults.millisec > tp_inst._defaults.millisecMax? tp_inst._defaults.millisecMax : tp_inst._defaults.millisec;
 			tp_inst.ampm = '';
 			tp_inst.$input = $input;
@@ -3940,7 +3940,7 @@ return VueRouter;
 			// Prevent displaying twice
 			if ($dp.find("div.ui-timepicker-div").length === 0 && o.showTimepicker) {
 				var noDisplay = ' style="display:none;"',
-					html = '<div class="ui-timepicker-div'+ (o.isRTL? ' ui-timepicker-rtl' : '') +'"><dl>' + '<dt class="ui_tpicker_time_label"' + ((o.showTime) ? '' : noDisplay) + '>' + o.timeText + '</dt>' + 
+					html = '<div class="ui-timepicker-div'+ (o.isRTL? ' ui-timepicker-rtl' : '') +'"><dl>' + '<dt class="ui_tpicker_time_label"' + ((o.showTime) ? '' : noDisplay) + '>' + o.timeText + '</dt>' +
 								'<dd class="ui_tpicker_time"' + ((o.showTime) ? '' : noDisplay) + '></dd>';
 
 				// Create the markup
@@ -3953,7 +3953,7 @@ return VueRouter;
 					max[litem] = parseInt((o[litem+'Max'] - ((o[litem+'Max'] - o[litem+'Min']) % o['step'+uitem])), 10);
 					gridSize[litem] = 0;
 
-					html += '<dt class="ui_tpicker_'+ litem +'_label"' + ((o['show'+uitem]) ? '' : noDisplay) + '>' + o[litem +'Text'] + '</dt>' + 
+					html += '<dt class="ui_tpicker_'+ litem +'_label"' + ((o['show'+uitem]) ? '' : noDisplay) + '>' + o[litem +'Text'] + '</dt>' +
 								'<dd class="ui_tpicker_'+ litem +'"><div class="ui_tpicker_'+ litem +'_slider"' + ((o['show'+uitem]) ? '' : noDisplay) + '></div>';
 
 					if (o['show'+uitem] && o[litem+'Grid'] > 0) {
@@ -3962,7 +3962,7 @@ return VueRouter;
 						if(litem == 'hour'){
 							for (var h = o[litem+'Min']; h <= max[litem]; h += parseInt(o[litem+'Grid'], 10)) {
 								gridSize[litem]++;
-								var tmph = $.datepicker.formatTime(useAmpm(o.pickerTimeFormat || o.timeFormat)? 'hht':'HH', {hour:h}, o);									
+								var tmph = $.datepicker.formatTime(useAmpm(o.pickerTimeFormat || o.timeFormat)? 'hht':'HH', {hour:h}, o);
 								html += '<td data-for="'+litem+'">' + tmph + '</td>';
 							}
 						}
@@ -3977,7 +3977,7 @@ return VueRouter;
 					}
 					html += '</dd>';
 				}
-				
+
 				// Timezone
 				html += '<dt class="ui_tpicker_timezone_label"' + ((o.showTimezone) ? '' : noDisplay) + '>' + o.timezoneText + '</dt>';
 				html += '<dd class="ui_tpicker_timezone" ' + ((o.showTimezone) ? '' : noDisplay) + '></dd>';
@@ -3991,7 +3991,7 @@ return VueRouter;
 					$tp.prepend('<div class="ui-widget-header ui-helper-clearfix ui-corner-all">' + '<div class="ui-datepicker-title">' + o.timeOnlyTitle + '</div>' + '</div>');
 					$dp.find('.ui-datepicker-header, .ui-datepicker-calendar').hide();
 				}
-				
+
 				// add sliders, adjust grids, add events
 				for(var i=0,l=tp_inst.units.length; i<l; i++){
 					litem = tp_inst.units[i];
@@ -4025,7 +4025,7 @@ return VueRouter;
 										}
 									}
 								}
-								
+
 								tp_inst.control.value(tp_inst, tp_inst[f+'_slider'], litem, n);
 
 								tp_inst._onTimeChange();
@@ -4067,7 +4067,7 @@ return VueRouter;
 					tp_inst._onSelectHandler();
 				});
 				// End timezone options
-				
+
 				// inject timepicker into datepicker
 				var $buttonPanel = $dp.find('.ui-datepicker-buttonpane');
 				if ($buttonPanel.length) {
@@ -4089,7 +4089,7 @@ return VueRouter;
 					var sliderAccessArgs = this._defaults.sliderAccessArgs,
 						rtl = this._defaults.isRTL;
 					sliderAccessArgs.isRTL = rtl;
-						
+
 					setTimeout(function() { // fix for inline mode
 						if ($tp.find('.ui-slider-access').length === 0) {
 							$tp.find('.ui-slider:visible').sliderAccess(sliderAccessArgs);
@@ -4291,8 +4291,8 @@ return VueRouter;
 
 			// If the update was done in the input field, the input field should not be updated.
 			// If the update was done using the sliders, update the input field.
-			var hasChanged = (hour != this.hour || minute != this.minute || second != this.second || millisec != this.millisec 
-								|| (this.ampm.length > 0 && (hour < 12) != ($.inArray(this.ampm.toUpperCase(), this.amNames) !== -1)) 
+			var hasChanged = (hour != this.hour || minute != this.minute || second != this.second || millisec != this.millisec
+								|| (this.ampm.length > 0 && (hour < 12) != ($.inArray(this.ampm.toUpperCase(), this.amNames) !== -1))
 								|| ((this.timezone === null && timezone != this.defaultTimezone) || (this.timezone !== null && timezone != this.timezone)));
 
 			if (hasChanged) {
@@ -4363,7 +4363,7 @@ return VueRouter;
 				timeAvailable = dt !== null && this.timeDefined;
 			this.formattedDate = $.datepicker.formatDate(dateFmt, (dt === null ? new Date() : dt), formatCfg);
 			var formattedDateTime = this.formattedDate;
-			
+
 			// if a slider was changed but datepicker doesn't have a value yet, set it
 			if(dp_inst.lastVal==""){
                 dp_inst.currentYear=dp_inst.selectedYear;
@@ -4373,7 +4373,7 @@ return VueRouter;
 
 			/*
 			* remove following lines to force every changes in date picker to change the input value
-			* Bug descriptions: when an input field has a default value, and click on the field to pop up the date picker. 
+			* Bug descriptions: when an input field has a default value, and click on the field to pop up the date picker.
 			* If the user manually empty the value in the input field, the date picker will never change selected value.
 			*/
 			//if (dp_inst.lastVal !== undefined && (dp_inst.lastVal.length > 0 && this.$input.val().length === 0)) {
@@ -4451,7 +4451,7 @@ return VueRouter;
 						stop: function(event, ui) {
 							tp_inst._onSelectHandler();
 						}
-					});	
+					});
 				},
 				options: function(tp_inst, obj, unit, opts, val){
 					if(tp_inst._defaults.isRTL){
@@ -4463,7 +4463,7 @@ return VueRouter;
 							}
 							return obj.slider(opts);
 						}
-						var min = opts.min, 
+						var min = opts.min,
 							max = opts.max;
 						opts.min = opts.max = null;
 						if(min !== undefined)
@@ -4494,7 +4494,7 @@ return VueRouter;
 						ul = tp_inst._defaults.timeFormat.indexOf('t') !== -1? 'toLowerCase':'toUpperCase',
 						m = 0;
 
-					for(var i=min; i<=max; i+=step){						
+					for(var i=min; i<=max; i+=step){
 						sel += '<option value="'+ i +'"'+ (i==val? ' selected':'') +'>';
 						if(unit == 'hour' && useAmpm(tp_inst._defaults.pickerTimeFormat || tp_inst._defaults.timeFormat))
 							sel += $.datepicker.formatTime("hh TT", {hour:i}, tp_inst._defaults);
@@ -4519,7 +4519,7 @@ return VueRouter;
 					if(typeof(opts) == 'string'){
 						if(val === undefined)
 							return $t.data(opts);
-						o[opts] = val;	
+						o[opts] = val;
 					}
 					else o = opts;
 					return tp_inst.control.create(tp_inst, obj, $t.data('unit'), $t.val(), o.min || $t.data('min'), o.max || $t.data('max'), o.step || $t.data('step'));
@@ -4595,7 +4595,7 @@ return VueRouter;
 	/*
 	* Public utility to parse time
 	*/
-	$.datepicker.parseTime = function(timeFormat, timeString, options) {		
+	$.datepicker.parseTime = function(timeFormat, timeString, options) {
 		var o = extendRemove(extendRemove({}, $.timepicker._defaults), options || {});
 
 		// Strict parse requires the timeString to match the timeFormat exactly
@@ -4760,11 +4760,11 @@ return VueRouter;
 				}
 				catch(err2){
 					$.timepicker.log("Unable to parse \ntimeString: "+ s +"\ntimeFormat: "+ f);
-				}				
+				}
 			}
 			return false;
 		}; // end looseParse
-		
+
 		if(typeof o.parse === "function"){
 			return o.parse(timeFormat, timeString, o)
 		}
@@ -4821,9 +4821,9 @@ return VueRouter;
 				return ('00' + time.millisec).slice(-3);
 			case 'z':
 				return time.timezone === null? options.defaultTimezone : time.timezone;
-			case 'T': 
+			case 'T':
 				return ampmName.charAt(0).toUpperCase();
-			case 'TT': 
+			case 'TT':
 				return ampmName.toUpperCase();
 			case 't':
 				return ampmName.charAt(0).toLowerCase();
@@ -4910,11 +4910,11 @@ return VueRouter;
 											.replace(/tT/g, ampm ? 'AaPpMm' : '')
 											.replace(/T/g, ampm ? 'AP' : '')
 											.replace(/tt/g, ampm ? 'apm' : '')
-											.replace(/t/g, ampm ? 'ap' : '') + 
-											" " + tp_inst._defaults.separator + 
-											tp_inst._defaults.timeSuffix + 
-											(tp_inst._defaults.showTimezone ? tp_inst._defaults.timezoneList.join('') : '') + 
-											(tp_inst._defaults.amNames.join('')) + (tp_inst._defaults.pmNames.join('')) + 
+											.replace(/t/g, ampm ? 'ap' : '') +
+											" " + tp_inst._defaults.separator +
+											tp_inst._defaults.timeSuffix +
+											(tp_inst._defaults.showTimezone ? tp_inst._defaults.timezoneList.join('') : '') +
+											(tp_inst._defaults.amNames.join('')) + (tp_inst._defaults.pmNames.join('')) +
 											dateChars,
 					chr = String.fromCharCode(event.charCode === undefined ? event.keyCode : event.charCode);
 				return event.ctrlKey || (chr < ' ' || !dateChars || datetimeChars.indexOf(chr) > -1);
@@ -4937,11 +4937,11 @@ return VueRouter;
 				var altFormat = tp_inst._defaults.altFormat || tp_inst._defaults.dateFormat,
 					date = this._getDate(inst),
 					formatCfg = $.datepicker._getFormatConfig(inst),
-					altFormattedDateTime = '', 
-					altSeparator = tp_inst._defaults.altSeparator ? tp_inst._defaults.altSeparator : tp_inst._defaults.separator, 
+					altFormattedDateTime = '',
+					altSeparator = tp_inst._defaults.altSeparator ? tp_inst._defaults.altSeparator : tp_inst._defaults.separator,
 					altTimeSuffix = tp_inst._defaults.altTimeSuffix ? tp_inst._defaults.altTimeSuffix : tp_inst._defaults.timeSuffix,
 					altTimeFormat = tp_inst._defaults.altTimeFormat !== null ? tp_inst._defaults.altTimeFormat : tp_inst._defaults.timeFormat;
-				
+
 				altFormattedDateTime += $.datepicker.formatTime(altTimeFormat, tp_inst, tp_inst._defaults) + altTimeSuffix;
 				if(!tp_inst._defaults.timeOnly && !tp_inst._defaults.altFieldTimeOnly && date !== null){
 					if(tp_inst._defaults.altFormat)
@@ -5038,7 +5038,7 @@ return VueRouter;
 			tp_inst.second = date ? date.getSeconds() : defaults.second;
 			tp_inst.millisec = date ? date.getMilliseconds() : defaults.millisec;
 
-			//check if within min/max times.. 
+			//check if within min/max times..
 			tp_inst._limitMinMaxDateTime(inst, true);
 
 			tp_inst._onTimeChange();
@@ -5293,7 +5293,7 @@ return VueRouter;
 	*/
 	var splitDateTime = function(dateFormat, dateTimeString, dateSettings, timeSettings) {
 		try {
-			// The idea is to get the number separator occurances in datetime and the time format requested (since time has 
+			// The idea is to get the number separator occurances in datetime and the time format requested (since time has
 			// fewer unknowns, mostly numbers and am/pm). We will use the time pattern to split.
 			var separator = timeSettings && timeSettings.separator ? timeSettings.separator : $.timepicker._defaults.separator,
 				format = timeSettings && timeSettings.timeFormat ? timeSettings.timeFormat : $.timepicker._defaults.timeFormat,
@@ -5462,7 +5462,7 @@ return VueRouter;
 				selected(this, startTime, 'maxDate');
 			}
 		}, options, options.end));
-		// timepicker doesn't provide access to its 'timeFormat' option, 
+		// timepicker doesn't provide access to its 'timeFormat' option,
 		// nor could I get datepicker.formatTime() to behave with times, so I
 		// have disabled reformatting for timepicker
 		if (method != 'timepicker' && options.reformat) {
@@ -7195,7 +7195,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 	function isWin(elem) {
 		return !elem.nodeName ||
 			$.inArray(elem.nodeName.toLowerCase(), ['iframe','#document','html','body']) !== -1;
-	}		
+	}
 
 	$.fn.scrollTo = function(target, duration, settings) {
 		if (typeof duration === 'object') {
@@ -7228,7 +7228,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var win = isWin(this),
 				elem = win ? this.contentWindow || window : this,
 				$elem = $(elem),
-				targ = target, 
+				targ = target,
 				attr = {},
 				toff;
 
@@ -7344,7 +7344,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 	}
 
 	// Add special hooks so that window scroll properties can be animated
-	$.Tween.propHooks.scrollLeft = 
+	$.Tween.propHooks.scrollLeft =
 	$.Tween.propHooks.scrollTop = {
 		get: function(t) {
 			return $(t.elem)[t.prop]();
@@ -8039,7 +8039,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 	var highlight = function($element, pattern) {
 		if (typeof pattern === 'string' && !pattern.length) return;
 		var regex = (typeof pattern === 'string') ? new RegExp(pattern, 'i') : pattern;
-	
+
 		var highlight = function(node) {
 			var skip = 0;
 			if (node.nodeType === 3) {
@@ -8062,12 +8062,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			return skip;
 		};
-	
+
 		return $element.each(function() {
 			highlight(this);
 		});
 	};
-	
+
 	/**
 	 * removeHighlight fn copied from highlight v5 and
 	 * edited to remove with() and pass js strict mode
@@ -8080,8 +8080,8 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			parent.normalize();
 		}).end();
 	};
-	
-	
+
+
 	var MicroEvent = function() {};
 	MicroEvent.prototype = {
 		on: function(event, fct){
@@ -8093,7 +8093,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var n = arguments.length;
 			if (n === 0) return delete this._events;
 			if (n === 1) return delete this._events[event];
-	
+
 			this._events = this._events || {};
 			if (event in this._events === false) return;
 			this._events[event].splice(this._events[event].indexOf(fct), 1);
@@ -8106,7 +8106,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 		}
 	};
-	
+
 	/**
 	 * Mixin will delegate all MicroEvent.js function in the destination object.
 	 *
@@ -8120,9 +8120,9 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			destObject.prototype[props[i]] = MicroEvent.prototype[props[i]];
 		}
 	};
-	
+
 	var IS_MAC        = /Mac/.test(navigator.userAgent);
-	
+
 	var KEY_A         = 65;
 	var KEY_COMMA     = 188;
 	var KEY_RETURN    = 13;
@@ -8139,18 +8139,18 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 	var KEY_CMD       = IS_MAC ? 91 : 17;
 	var KEY_CTRL      = IS_MAC ? 18 : 17;
 	var KEY_TAB       = 9;
-	
+
 	var TAG_SELECT    = 1;
 	var TAG_INPUT     = 2;
-	
+
 	// for now, android support in general is too spotty to support validity
 	var SUPPORTS_VALIDITY_API = !/android/i.test(window.navigator.userAgent) && !!document.createElement('input').validity;
-	
-	
+
+
 	var isset = function(object) {
 		return typeof object !== 'undefined';
 	};
-	
+
 	/**
 	 * Converts a scalar to its best string representation
 	 * for hash keys and HTML attribute values.
@@ -8172,7 +8172,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		if (typeof value === 'boolean') return value ? '1' : '0';
 		return value + '';
 	};
-	
+
 	/**
 	 * Escapes a string for use within HTML.
 	 *
@@ -8186,7 +8186,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			.replace(/>/g, '&gt;')
 			.replace(/"/g, '&quot;');
 	};
-	
+
 	/**
 	 * Escapes "$" characters in replacement strings.
 	 *
@@ -8196,9 +8196,9 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 	var escape_replace = function(str) {
 		return (str + '').replace(/\$/g, '$$$$');
 	};
-	
+
 	var hook = {};
-	
+
 	/**
 	 * Wraps `method` on `self` so that `fn`
 	 * is invoked before the original method.
@@ -8214,7 +8214,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			return original.apply(self, arguments);
 		};
 	};
-	
+
 	/**
 	 * Wraps `method` on `self` so that `fn`
 	 * is invoked after the original method.
@@ -8231,7 +8231,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			return result;
 		};
 	};
-	
+
 	/**
 	 * Wraps `fn` so that it can only be invoked once.
 	 *
@@ -8246,7 +8246,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			fn.apply(this, arguments);
 		};
 	};
-	
+
 	/**
 	 * Wraps `fn` so that it can only be called once
 	 * every `delay` milliseconds (invoked on the falling edge).
@@ -8266,7 +8266,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}, delay);
 		};
 	};
-	
+
 	/**
 	 * Debounce all fired events types listed in `types`
 	 * while executing the provided `fn`.
@@ -8279,7 +8279,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		var type;
 		var trigger = self.trigger;
 		var event_args = {};
-	
+
 		// override trigger method
 		self.trigger = function() {
 			var type = arguments[0];
@@ -8289,11 +8289,11 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				return trigger.apply(self, arguments);
 			}
 		};
-	
+
 		// invoke provided function
 		fn.apply(self, []);
 		self.trigger = trigger;
-	
+
 		// trigger queued events
 		for (type in event_args) {
 			if (event_args.hasOwnProperty(type)) {
@@ -8301,7 +8301,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 		}
 	};
-	
+
 	/**
 	 * A workaround for http://bugs.jquery.com/ticket/6696
 	 *
@@ -8320,7 +8320,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			return fn.apply(this, [e]);
 		});
 	};
-	
+
 	/**
 	 * Determines the current selection within a text input control.
 	 * Returns an object containing:
@@ -8345,7 +8345,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		}
 		return result;
 	};
-	
+
 	/**
 	 * Copies CSS properties from one element to another.
 	 *
@@ -8364,7 +8364,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		}
 		$to.css(styles);
 	};
-	
+
 	/**
 	 * Measures the width of a string within a
 	 * parent element (in pixels).
@@ -8377,7 +8377,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		if (!str) {
 			return 0;
 		}
-	
+
 		var $test = $('<test>').css({
 			position: 'absolute',
 			top: -99999,
@@ -8386,7 +8386,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			padding: 0,
 			whiteSpace: 'pre'
 		}).text(str).appendTo('body');
-	
+
 		transferStyles($parent, $test, [
 			'letterSpacing',
 			'fontSize',
@@ -8394,13 +8394,13 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			'fontWeight',
 			'textTransform'
 		]);
-	
+
 		var width = $test.width();
 		$test.remove();
-	
+
 		return width;
 	};
-	
+
 	/**
 	 * Sets up an input to grow horizontally as the user
 	 * types. If the value is changed manually, you can
@@ -8412,16 +8412,16 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 	 */
 	var autoGrow = function($input) {
 		var currentWidth = null;
-	
+
 		var update = function(e, options) {
 			var value, keyCode, printable, placeholder, width;
 			var shift, character, selection;
 			e = e || window.event || {};
 			options = options || {};
-	
+
 			if (e.metaKey || e.altKey) return;
 			if (!options.force && $input.data('grow') === false) return;
-	
+
 			value = $input.val();
 			if (e.type && e.type.toLowerCase() === 'keydown') {
 				keyCode = e.keyCode;
@@ -8431,7 +8431,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					(keyCode >= 48 && keyCode <= 57)  || // 0-9
 					keyCode === 32 // space
 				);
-	
+
 				if (keyCode === KEY_DELETE || keyCode === KEY_BACKSPACE) {
 					selection = getSelection($input[0]);
 					if (selection.length) {
@@ -8449,12 +8449,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					value += character;
 				}
 			}
-	
+
 			placeholder = $input.attr('placeholder');
 			if (!value && placeholder) {
 				value = placeholder;
 			}
-	
+
 			width = measureString(value, $input) + 4;
 			if (width !== currentWidth) {
 				currentWidth = width;
@@ -8462,25 +8462,25 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				$input.triggerHandler('resize');
 			}
 		};
-	
+
 		$input.on('keydown keyup update blur', update);
 		update();
 	};
-	
+
 	var domToString = function(d) {
 		var tmp = document.createElement('div');
-	
+
 		tmp.appendChild(d.cloneNode(true));
-	
+
 		return tmp.innerHTML;
 	};
-	
+
 	var logError = function(message, options){
 		if(!options) options = {};
 		var component = "Selectize";
-	
+
 		console.error(component + ": " + message)
-	
+
 		if(options.explanation){
 			// console.group is undefined in <IE11
 			if(console.group) console.group();
@@ -8488,18 +8488,18 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			if(console.group) console.groupEnd();
 		}
 	}
-	
-	
+
+
 	var Selectize = function($input, settings) {
 		var key, i, n, dir, input, self = this;
 		input = $input[0];
 		input.selectize = self;
-	
+
 		// detect rtl environment
 		var computedStyle = window.getComputedStyle && window.getComputedStyle(input, null);
 		dir = computedStyle ? computedStyle.getPropertyValue('direction') : input.currentStyle && input.currentStyle.direction;
 		dir = dir || $input.parents('[dir]:first').attr('dir') || '';
-	
+
 		// setup default state
 		$.extend(self, {
 			order            : 0,
@@ -8508,7 +8508,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			tabIndex         : $input.attr('tabindex') || '',
 			tagType          : input.tagName.toLowerCase() === 'select' ? TAG_SELECT : TAG_INPUT,
 			rtl              : /rtl/i.test(dir),
-	
+
 			eventNS          : '.selectize' + (++Selectize.count),
 			highlightedValue : null,
 			isOpen           : false,
@@ -8531,10 +8531,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			caretPos         : 0,
 			loading          : 0,
 			loadedSearches   : {},
-	
+
 			$activeOption    : null,
 			$activeItems     : [],
-	
+
 			optgroups        : {},
 			options          : {},
 			userOptions      : {},
@@ -8542,10 +8542,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			renderCache      : {},
 			onSearchChange   : settings.loadThrottle === null ? self.onSearchChange : debounce(self.onSearchChange, settings.loadThrottle)
 		});
-	
+
 		// search system
 		self.sifter = new Sifter(this.options, {diacritics: settings.diacritics});
-	
+
 		// build options table
 		if (self.settings.options) {
 			for (i = 0, n = self.settings.options.length; i < n; i++) {
@@ -8553,7 +8553,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			delete self.settings.options;
 		}
-	
+
 		// build optgroup table
 		if (self.settings.optgroups) {
 			for (i = 0, n = self.settings.optgroups.length; i < n; i++) {
@@ -8561,24 +8561,24 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			delete self.settings.optgroups;
 		}
-	
+
 		// option-dependent defaults
 		self.settings.mode = self.settings.mode || (self.settings.maxItems === 1 ? 'single' : 'multi');
 		if (typeof self.settings.hideSelected !== 'boolean') {
 			self.settings.hideSelected = self.settings.mode === 'multi';
 		}
-	
+
 		self.initializePlugins(self.settings.plugins);
 		self.setupCallbacks();
 		self.setupTemplates();
 		self.setup();
 	};
-	
+
 	// mixins
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-	
+
 	MicroEvent.mixin(Selectize);
-	
+
 	if(typeof MicroPlugin !== "undefined"){
 		MicroPlugin.mixin(Selectize);
 	}else{
@@ -8589,13 +8589,13 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				"load Selectize."}
 		);
 	}
-	
-	
+
+
 	// methods
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-	
+
 	$.extend(Selectize.prototype, {
-	
+
 		/**
 		 * Creates all elements and sets up event bindings.
 		 */
@@ -8606,7 +8606,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var $window   = $(window);
 			var $document = $(document);
 			var $input    = self.$input;
-	
+
 			var $wrapper;
 			var $control;
 			var $control_input;
@@ -8619,74 +8619,74 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var classes;
 			var classes_plugins;
 			var inputId;
-	
+
 			inputMode         = self.settings.mode;
 			classes           = $input.attr('class') || '';
-	
+
 			$wrapper          = $('<div>').addClass(settings.wrapperClass).addClass(classes).addClass(inputMode);
 			$control          = $('<div>').addClass(settings.inputClass).addClass('items').appendTo($wrapper);
 			$control_input    = $('<input type="text" autocomplete="off" />').appendTo($control).attr('tabindex', $input.is(':disabled') ? '-1' : self.tabIndex);
 			$dropdown_parent  = $(settings.dropdownParent || $wrapper);
 			$dropdown         = $('<div>').addClass(settings.dropdownClass).addClass(inputMode).hide().appendTo($dropdown_parent);
 			$dropdown_content = $('<div>').addClass(settings.dropdownContentClass).appendTo($dropdown);
-	
+
 			if(inputId = $input.attr('id')) {
 				$control_input.attr('id', inputId + '-selectized');
 				$("label[for='"+inputId+"']").attr('for', inputId + '-selectized');
 			}
-	
+
 			if(self.settings.copyClassesToDropdown) {
 				$dropdown.addClass(classes);
 			}
-	
+
 			$wrapper.css({
 				width: $input[0].style.width
 			});
-	
+
 			if (self.plugins.names.length) {
 				classes_plugins = 'plugin-' + self.plugins.names.join(' plugin-');
 				$wrapper.addClass(classes_plugins);
 				$dropdown.addClass(classes_plugins);
 			}
-	
+
 			if ((settings.maxItems === null || settings.maxItems > 1) && self.tagType === TAG_SELECT) {
 				$input.attr('multiple', 'multiple');
 			}
-	
+
 			if (self.settings.placeholder) {
 				$control_input.attr('placeholder', settings.placeholder);
 			}
-	
+
 			// if splitOn was not passed in, construct it from the delimiter to allow pasting universally
 			if (!self.settings.splitOn && self.settings.delimiter) {
 				var delimiterEscaped = self.settings.delimiter.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 				self.settings.splitOn = new RegExp('\\s*' + delimiterEscaped + '+\\s*');
 			}
-	
+
 			if ($input.attr('autocorrect')) {
 				$control_input.attr('autocorrect', $input.attr('autocorrect'));
 			}
-	
+
 			if ($input.attr('autocapitalize')) {
 				$control_input.attr('autocapitalize', $input.attr('autocapitalize'));
 			}
-	
+
 			self.$wrapper          = $wrapper;
 			self.$control          = $control;
 			self.$control_input    = $control_input;
 			self.$dropdown         = $dropdown;
 			self.$dropdown_content = $dropdown_content;
-	
+
 			$dropdown.on('mouseenter', '[data-selectable]', function() { return self.onOptionHover.apply(self, arguments); });
 			$dropdown.on('mousedown click', '[data-selectable]', function() { return self.onOptionSelect.apply(self, arguments); });
 			watchChildEvent($control, 'mousedown', '*:not(input)', function() { return self.onItemSelect.apply(self, arguments); });
 			autoGrow($control_input);
-	
+
 			$control.on({
 				mousedown : function() { return self.onMouseDown.apply(self, arguments); },
 				click     : function() { return self.onClick.apply(self, arguments); }
 			});
-	
+
 			$control_input.on({
 				mousedown : function(e) { e.stopPropagation(); },
 				keydown   : function() { return self.onKeyDown.apply(self, arguments); },
@@ -8697,19 +8697,19 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				focus     : function() { self.ignoreBlur = false; return self.onFocus.apply(self, arguments); },
 				paste     : function() { return self.onPaste.apply(self, arguments); }
 			});
-	
+
 			$document.on('keydown' + eventNS, function(e) {
 				self.isCmdDown = e[IS_MAC ? 'metaKey' : 'ctrlKey'];
 				self.isCtrlDown = e[IS_MAC ? 'altKey' : 'ctrlKey'];
 				self.isShiftDown = e.shiftKey;
 			});
-	
+
 			$document.on('keyup' + eventNS, function(e) {
 				if (e.keyCode === KEY_CTRL) self.isCtrlDown = false;
 				if (e.keyCode === KEY_SHIFT) self.isShiftDown = false;
 				if (e.keyCode === KEY_CMD) self.isCmdDown = false;
 			});
-	
+
 			$document.on('mousedown' + eventNS, function(e) {
 				if (self.isFocused) {
 					// prevent events on the dropdown scrollbar from causing the control to blur
@@ -8722,7 +8722,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					}
 				}
 			});
-	
+
 			$window.on(['scroll' + eventNS, 'resize' + eventNS].join(' '), function() {
 				if (self.isOpen) {
 					self.positionDropdown.apply(self, arguments);
@@ -8731,21 +8731,21 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			$window.on('mousemove' + eventNS, function() {
 				self.ignoreHover = false;
 			});
-	
+
 			// store original children and tab index so that they can be
 			// restored when the destroy() method is called.
 			this.revertSettings = {
 				$children : $input.children().detach(),
 				tabindex  : $input.attr('tabindex')
 			};
-	
+
 			$input.attr('tabindex', -1).hide().after(self.$wrapper);
-	
+
 			if ($.isArray(settings.items)) {
 				self.setValue(settings.items);
 				delete settings.items;
 			}
-	
+
 			// feature detect for the validation API
 			if (SUPPORTS_VALIDITY_API) {
 				$input.on('invalid' + eventNS, function(e) {
@@ -8754,30 +8754,30 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					self.refreshState();
 				});
 			}
-	
+
 			self.updateOriginalInput();
 			self.refreshItems();
 			self.refreshState();
 			self.updatePlaceholder();
 			self.isSetup = true;
-	
+
 			if ($input.is(':disabled')) {
 				self.disable();
 			}
-	
+
 			self.on('change', this.onChange);
-	
+
 			$input.data('selectize', self);
 			$input.addClass('selectized');
 			self.trigger('initialize');
-	
+
 			// preload options
 			if (settings.preload === true) {
 				self.onSearchChange('');
 			}
-	
+
 		},
-	
+
 		/**
 		 * Sets up default rendering functions.
 		 */
@@ -8785,7 +8785,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self = this;
 			var field_label = self.settings.labelField;
 			var field_optgroup = self.settings.optgroupLabelField;
-	
+
 			var templates = {
 				'optgroup': function(data) {
 					return '<div class="optgroup">' + data.html + '</div>';
@@ -8803,10 +8803,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					return '<div class="create">Add <strong>' + escape(data.input) + '</strong>&hellip;</div>';
 				}
 			};
-	
+
 			self.settings.render = $.extend({}, templates, self.settings.render);
 		},
-	
+
 		/**
 		 * Maps fired events to callbacks provided
 		 * in the settings used when creating the control.
@@ -8831,7 +8831,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				'focus'           : 'onFocus',
 				'blur'            : 'onBlur'
 			};
-	
+
 			for (key in callbacks) {
 				if (callbacks.hasOwnProperty(key)) {
 					fn = this.settings[callbacks[key]];
@@ -8839,7 +8839,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 			}
 		},
-	
+
 		/**
 		 * Triggered when the main control element
 		 * has a click event.
@@ -8849,7 +8849,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		onClick: function(e) {
 			var self = this;
-	
+
 			// necessary for mobile webkit devices (manual focus triggering
 			// is ignored unless invoked within a click event)
 			if (!self.isFocused) {
@@ -8857,7 +8857,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				e.preventDefault();
 			}
 		},
-	
+
 		/**
 		 * Triggered when the main control element
 		 * has a mouse down event.
@@ -8869,7 +8869,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self = this;
 			var defaultPrevented = e.isDefaultPrevented();
 			var $target = $(e.target);
-	
+
 			if (self.isFocused) {
 				// retain focus by preventing native handling. if the
 				// event target is the input it should not be modified.
@@ -8892,7 +8892,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 			}
 		},
-	
+
 		/**
 		 * Triggered when the value of the control has been changed.
 		 * This should propagate the event to the original DOM
@@ -8901,7 +8901,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		onChange: function() {
 			this.$input.trigger('change');
 		},
-	
+
 		/**
 		 * Triggered on <input> paste.
 		 *
@@ -8910,21 +8910,21 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		onPaste: function(e) {
 			var self = this;
-	
+
 			if (self.isFull() || self.isInputHidden || self.isLocked) {
 				e.preventDefault();
 				return;
 			}
-	
+
 			// If a regex or string is included, this will split the pasted
 			// input and create Items for each separate value
 			if (self.settings.splitOn) {
-	
+
 				// Wait for pasted text to be recognized in value
 				setTimeout(function() {
 					var pastedText = self.$control_input.val();
 					if(!pastedText.match(self.settings.splitOn)){ return }
-	
+
 					var splitInput = $.trim(pastedText).split(self.settings.splitOn);
 					for (var i = 0, n = splitInput.length; i < n; i++) {
 						self.createItem(splitInput[i]);
@@ -8932,7 +8932,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}, 0);
 			}
 		},
-	
+
 		/**
 		 * Triggered on <input> keypress.
 		 *
@@ -8948,7 +8948,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				return false;
 			}
 		},
-	
+
 		/**
 		 * Triggered on <input> keydown.
 		 *
@@ -8958,14 +8958,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		onKeyDown: function(e) {
 			var isInput = e.target === this.$control_input[0];
 			var self = this;
-	
+
 			if (self.isLocked) {
 				if (e.keyCode !== KEY_TAB) {
 					e.preventDefault();
 				}
 				return;
 			}
-	
+
 			switch (e.keyCode) {
 				case KEY_A:
 					if (self.isCmdDown) {
@@ -9017,7 +9017,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				case KEY_TAB:
 					if (self.settings.selectOnTab && self.isOpen && self.$activeOption) {
 						self.onOptionSelect({currentTarget: self.$activeOption});
-	
+
 						// Default behaviour is to jump to the next field, we only want this
 						// if the current field doesn't accept any more entries
 						if (!self.isFull()) {
@@ -9033,13 +9033,13 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					self.deleteSelection(e);
 					return;
 			}
-	
+
 			if ((self.isFull() || self.isInputHidden) && !(IS_MAC ? e.metaKey : e.ctrlKey)) {
 				e.preventDefault();
 				return;
 			}
 		},
-	
+
 		/**
 		 * Triggered on <input> keyup.
 		 *
@@ -9048,7 +9048,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		onKeyUp: function(e) {
 			var self = this;
-	
+
 			if (self.isLocked) return e && e.preventDefault();
 			var value = self.$control_input.val() || '';
 			if (self.lastValue !== value) {
@@ -9058,7 +9058,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.trigger('type', value);
 			}
 		},
-	
+
 		/**
 		 * Invokes the user-provide option provider / loader.
 		 *
@@ -9077,7 +9077,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				fn.apply(self, [value, callback]);
 			});
 		},
-	
+
 		/**
 		 * Triggered on <input> focus.
 		 *
@@ -9087,28 +9087,28 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		onFocus: function(e) {
 			var self = this;
 			var wasFocused = self.isFocused;
-	
+
 			if (self.isDisabled) {
 				self.blur();
 				e && e.preventDefault();
 				return false;
 			}
-	
+
 			if (self.ignoreFocus) return;
 			self.isFocused = true;
 			if (self.settings.preload === 'focus') self.onSearchChange('');
-	
+
 			if (!wasFocused) self.trigger('focus');
-	
+
 			if (!self.$activeItems.length) {
 				self.showInput();
 				self.setActiveItem(null);
 				self.refreshOptions(!!self.settings.openOnFocus);
 			}
-	
+
 			self.refreshState();
 		},
-	
+
 		/**
 		 * Triggered on <input> blur.
 		 *
@@ -9119,7 +9119,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self = this;
 			if (!self.isFocused) return;
 			self.isFocused = false;
-	
+
 			if (self.ignoreFocus) {
 				return;
 			} else if (!self.ignoreBlur && document.activeElement === self.$dropdown_content[0]) {
@@ -9128,7 +9128,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.onFocus(e);
 				return;
 			}
-	
+
 			var deactivate = function() {
 				self.close();
 				self.setTextboxValue('');
@@ -9136,14 +9136,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.setActiveOption(null);
 				self.setCaret(self.items.length);
 				self.refreshState();
-	
+
 				// IE11 bug: element still marked as active
 				dest && dest.focus && dest.focus();
-	
+
 				self.ignoreFocus = false;
 				self.trigger('blur');
 			};
-	
+
 			self.ignoreFocus = true;
 			if (self.settings.create && self.settings.createOnBlur) {
 				self.createItem(null, false, deactivate);
@@ -9151,7 +9151,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				deactivate();
 			}
 		},
-	
+
 		/**
 		 * Triggered when the user rolls over
 		 * an option in the autocomplete dropdown menu.
@@ -9163,7 +9163,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			if (this.ignoreHover) return;
 			this.setActiveOption(e.currentTarget, false);
 		},
-	
+
 		/**
 		 * Triggered when the user clicks on an option
 		 * in the autocomplete dropdown menu.
@@ -9173,12 +9173,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		onOptionSelect: function(e) {
 			var value, $target, $option, self = this;
-	
+
 			if (e.preventDefault) {
 				e.preventDefault();
 				e.stopPropagation();
 			}
-	
+
 			$target = $(e.currentTarget);
 			if ($target.hasClass('create')) {
 				self.createItem(null, function() {
@@ -9200,7 +9200,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 			}
 		},
-	
+
 		/**
 		 * Triggered when the user clicks on an item
 		 * that has been selected.
@@ -9210,14 +9210,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		onItemSelect: function(e) {
 			var self = this;
-	
+
 			if (self.isLocked) return;
 			if (self.settings.mode === 'multi') {
 				e.preventDefault();
 				self.setActiveItem(e.currentTarget, e);
 			}
 		},
-	
+
 		/**
 		 * Invokes the provided method that provides
 		 * results to a callback---which are then added
@@ -9228,7 +9228,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		load: function(fn) {
 			var self = this;
 			var $wrapper = self.$wrapper.addClass(self.settings.loadingClass);
-	
+
 			self.loading++;
 			fn.apply(self, [function(results) {
 				self.loading = Math.max(self.loading - 1, 0);
@@ -9242,7 +9242,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.trigger('load', results);
 			}]);
 		},
-	
+
 		/**
 		 * Sets the input field of the control to the specified value.
 		 *
@@ -9256,7 +9256,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				this.lastValue = value;
 			}
 		},
-	
+
 		/**
 		 * Returns the value of the control. If multiple items
 		 * can be selected (e.g. <select multiple>), this returns
@@ -9272,7 +9272,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				return this.items.join(this.settings.delimiter);
 			}
 		},
-	
+
 		/**
 		 * Resets the selected items to the given value.
 		 *
@@ -9280,13 +9280,13 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		setValue: function(value, silent) {
 			var events = silent ? [] : ['change'];
-	
+
 			debounce_events(this, events, function() {
 				this.clear(silent);
 				this.addItems(value, silent);
 			});
 		},
-	
+
 		/**
 		 * Sets the selected item.
 		 *
@@ -9298,10 +9298,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var eventName;
 			var i, idx, begin, end, item, swap;
 			var $last;
-	
+
 			if (self.settings.mode === 'single') return;
 			$item = $($item);
-	
+
 			// clear the active selection
 			if (!$item.length) {
 				$(self.$activeItems).removeClass('active');
@@ -9311,10 +9311,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 				return;
 			}
-	
+
 			// modify selection
 			eventName = e && e.type.toLowerCase();
-	
+
 			if (eventName === 'mousedown' && self.isShiftDown && self.$activeItems.length) {
 				$last = self.$control.children('.active:last');
 				begin = Array.prototype.indexOf.apply(self.$control[0].childNodes, [$last[0]]);
@@ -9344,14 +9344,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				$(self.$activeItems).removeClass('active');
 				self.$activeItems = [$item.addClass('active')[0]];
 			}
-	
+
 			// ensure control has focus
 			self.hideInput();
 			if (!this.isFocused) {
 				self.focus();
 			}
 		},
-	
+
 		/**
 		 * Sets the selected item in the dropdown menu
 		 * of available options.
@@ -9364,40 +9364,40 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var height_menu, height_item, y;
 			var scroll_top, scroll_bottom;
 			var self = this;
-	
+
 			if (self.$activeOption) self.$activeOption.removeClass('active');
 			self.$activeOption = null;
-	
+
 			$option = $($option);
 			if (!$option.length) return;
-	
+
 			self.$activeOption = $option.addClass('active');
-	
+
 			if (scroll || !isset(scroll)) {
-	
+
 				height_menu   = self.$dropdown_content.height();
 				height_item   = self.$activeOption.outerHeight(true);
 				scroll        = self.$dropdown_content.scrollTop() || 0;
 				y             = self.$activeOption.offset().top - self.$dropdown_content.offset().top + scroll;
 				scroll_top    = y;
 				scroll_bottom = y - height_menu + height_item;
-	
+
 				if (y + height_item > height_menu + scroll) {
 					self.$dropdown_content.stop().animate({scrollTop: scroll_bottom}, animate ? self.settings.scrollDuration : 0);
 				} else if (y < scroll) {
 					self.$dropdown_content.stop().animate({scrollTop: scroll_top}, animate ? self.settings.scrollDuration : 0);
 				}
-	
+
 			}
 		},
-	
+
 		/**
 		 * Selects all items (CTRL + A).
 		 */
 		selectAll: function() {
 			var self = this;
 			if (self.settings.mode === 'single') return;
-	
+
 			self.$activeItems = Array.prototype.slice.apply(self.$control.children(':not(input)').addClass('active'));
 			if (self.$activeItems.length) {
 				self.hideInput();
@@ -9405,19 +9405,19 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			self.focus();
 		},
-	
+
 		/**
 		 * Hides the input element out of view, while
 		 * retaining its focus.
 		 */
 		hideInput: function() {
 			var self = this;
-	
+
 			self.setTextboxValue('');
 			self.$control_input.css({opacity: 0, position: 'absolute', left: self.rtl ? 10000 : -10000});
 			self.isInputHidden = true;
 		},
-	
+
 		/**
 		 * Restores input visibility.
 		 */
@@ -9425,14 +9425,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			this.$control_input.css({opacity: 1, position: 'relative', left: 0});
 			this.isInputHidden = false;
 		},
-	
+
 		/**
 		 * Gives the control focus.
 		 */
 		focus: function() {
 			var self = this;
 			if (self.isDisabled) return;
-	
+
 			self.ignoreFocus = true;
 			self.$control_input[0].focus();
 			window.setTimeout(function() {
@@ -9440,7 +9440,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.onFocus();
 			}, 0);
 		},
-	
+
 		/**
 		 * Forces the control out of focus.
 		 *
@@ -9450,7 +9450,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			this.$control_input[0].blur();
 			this.onBlur(null, dest);
 		},
-	
+
 		/**
 		 * Returns a function that scores an object
 		 * to show how good of a match it is to the
@@ -9463,7 +9463,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		getScoreFunction: function(query) {
 			return this.sifter.getScoreFunction(query, this.getSearchOptions());
 		},
-	
+
 		/**
 		 * Returns search options for sifter (the system
 		 * for scoring and sorting results).
@@ -9477,14 +9477,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			if (typeof sort === 'string') {
 				sort = [{field: sort}];
 			}
-	
+
 			return {
 				fields      : settings.searchField,
 				conjunction : settings.searchConjunction,
 				sort        : sort
 			};
 		},
-	
+
 		/**
 		 * Searches through available options and returns
 		 * a sorted array of matches.
@@ -9504,7 +9504,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self     = this;
 			var settings = self.settings;
 			var options  = this.getSearchOptions();
-	
+
 			// validate user-provided result scoring function
 			if (settings.score) {
 				calculateScore = self.settings.score.apply(this, [query]);
@@ -9512,7 +9512,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					throw new Error('Selectize "score" setting must be a function that returns a function');
 				}
 			}
-	
+
 			// perform search
 			if (query !== self.lastQuery) {
 				self.lastQuery = query;
@@ -9521,7 +9521,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			} else {
 				result = $.extend(true, {}, self.currentResults);
 			}
-	
+
 			// filter out selected items
 			if (settings.hideSelected) {
 				for (i = result.items.length - 1; i >= 0; i--) {
@@ -9530,10 +9530,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					}
 				}
 			}
-	
+
 			return result;
 		},
-	
+
 		/**
 		 * Refreshes the list of available options shown
 		 * in the autocomplete dropdown menu.
@@ -9543,33 +9543,33 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		refreshOptions: function(triggerDropdown) {
 			var i, j, k, n, groups, groups_order, option, option_html, optgroup, optgroups, html, html_children, has_create_option;
 			var $active, $active_before, $create;
-	
+
 			if (typeof triggerDropdown === 'undefined') {
 				triggerDropdown = true;
 			}
-	
+
 			var self              = this;
 			var query             = $.trim(self.$control_input.val());
 			var results           = self.search(query);
 			var $dropdown_content = self.$dropdown_content;
 			var active_before     = self.$activeOption && hash_key(self.$activeOption.attr('data-value'));
-	
+
 			// build markup
 			n = results.items.length;
 			if (typeof self.settings.maxOptions === 'number') {
 				n = Math.min(n, self.settings.maxOptions);
 			}
-	
+
 			// render and group available options individually
 			groups = {};
 			groups_order = [];
-	
+
 			for (i = 0; i < n; i++) {
 				option      = self.options[results.items[i].id];
 				option_html = self.render('option', option);
 				optgroup    = option[self.settings.optgroupField] || '';
 				optgroups   = $.isArray(optgroup) ? optgroup : [optgroup];
-	
+
 				for (j = 0, k = optgroups && optgroups.length; j < k; j++) {
 					optgroup = optgroups[j];
 					if (!self.optgroups.hasOwnProperty(optgroup)) {
@@ -9582,7 +9582,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					groups[optgroup].appendChild(option_html);
 				}
 			}
-	
+
 			// sort optgroups
 			if (this.settings.lockOptgroupOrder) {
 				groups_order.sort(function(a, b) {
@@ -9591,7 +9591,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					return a_order - b_order;
 				});
 			}
-	
+
 			// render optgroup headers & join groups
 			html = document.createDocumentFragment();
 			for (i = 0, n = groups_order.length; i < n; i++) {
@@ -9602,7 +9602,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					html_children = document.createDocumentFragment();
 					html_children.appendChild(self.render('optgroup_header', self.optgroups[optgroup]));
 					html_children.appendChild(groups[optgroup]);
-	
+
 					html.appendChild(self.render('optgroup', $.extend({}, self.optgroups[optgroup], {
 						html: domToString(html_children),
 						dom:  html_children
@@ -9611,9 +9611,9 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					html.appendChild(groups[optgroup]);
 				}
 			}
-	
+
 			$dropdown_content.html(html);
-	
+
 			// highlight matching terms inline
 			if (self.settings.highlight && results.query.length && results.tokens.length) {
 				$dropdown_content.removeHighlight();
@@ -9621,21 +9621,21 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					highlight($dropdown_content, results.tokens[i].regex);
 				}
 			}
-	
+
 			// add "selected" class to selected options
 			if (!self.settings.hideSelected) {
 				for (i = 0, n = self.items.length; i < n; i++) {
 					self.getOption(self.items[i]).addClass('selected');
 				}
 			}
-	
+
 			// add create option
 			has_create_option = self.canCreate(query);
 			if (has_create_option) {
 				$dropdown_content.prepend(self.render('option_create', {input: query}));
 				$create = $($dropdown_content[0].childNodes[0]);
 			}
-	
+
 			// activate
 			self.hasOptions = results.items.length > 0 || has_create_option;
 			if (self.hasOptions) {
@@ -9663,7 +9663,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				if (triggerDropdown && self.isOpen) { self.close(); }
 			}
 		},
-	
+
 		/**
 		 * Adds an available option. If it already exists,
 		 * nothing will happen. Note: this does not refresh
@@ -9678,21 +9678,21 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		addOption: function(data) {
 			var i, n, value, self = this;
-	
+
 			if ($.isArray(data)) {
 				for (i = 0, n = data.length; i < n; i++) {
 					self.addOption(data[i]);
 				}
 				return;
 			}
-	
+
 			if (value = self.registerOption(data)) {
 				self.userOptions[value] = true;
 				self.lastQuery = null;
 				self.trigger('option_add', value, data);
 			}
 		},
-	
+
 		/**
 		 * Registers an option to the pool of options.
 		 *
@@ -9706,7 +9706,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			this.options[key] = data;
 			return key;
 		},
-	
+
 		/**
 		 * Registers an option group to the pool of option groups.
 		 *
@@ -9716,12 +9716,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		registerOptionGroup: function(data) {
 			var key = hash_key(data[this.settings.optgroupValueField]);
 			if (!key) return false;
-	
+
 			data.$order = data.$order || ++this.order;
 			this.optgroups[key] = data;
 			return key;
 		},
-	
+
 		/**
 		 * Registers a new optgroup for options
 		 * to be bucketed into.
@@ -9735,7 +9735,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				this.trigger('optgroup_add', id, data);
 			}
 		},
-	
+
 		/**
 		 * Removes an existing option group.
 		 *
@@ -9748,7 +9748,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				this.trigger('optgroup_remove', id);
 			}
 		},
-	
+
 		/**
 		 * Clears all existing option groups.
 		 */
@@ -9757,7 +9757,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			this.renderCache = {};
 			this.trigger('optgroup_clear');
 		},
-	
+
 		/**
 		 * Updates an option available for selection. If
 		 * it is visible in the selected items or options
@@ -9770,17 +9770,17 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self = this;
 			var $item, $item_new;
 			var value_new, index_item, cache_items, cache_options, order_old;
-	
+
 			value     = hash_key(value);
 			value_new = hash_key(data[self.settings.valueField]);
-	
+
 			// sanity checks
 			if (value === null) return;
 			if (!self.options.hasOwnProperty(value)) return;
 			if (typeof value_new !== 'string') throw new Error('Value must be set in option data');
-	
+
 			order_old = self.options[value].$order;
-	
+
 			// update references
 			if (value_new !== value) {
 				delete self.options[value];
@@ -9791,11 +9791,11 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			data.$order = data.$order || order_old;
 			self.options[value_new] = data;
-	
+
 			// invalidate render cache
 			cache_items = self.renderCache['item'];
 			cache_options = self.renderCache['option'];
-	
+
 			if (cache_items) {
 				delete cache_items[value];
 				delete cache_items[value_new];
@@ -9804,7 +9804,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				delete cache_options[value];
 				delete cache_options[value_new];
 			}
-	
+
 			// update the item if it's selected
 			if (self.items.indexOf(value_new) !== -1) {
 				$item = self.getItem(value);
@@ -9812,16 +9812,16 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				if ($item.hasClass('active')) $item_new.addClass('active');
 				$item.replaceWith($item_new);
 			}
-	
+
 			// invalidate last query because we might have updated the sortField
 			self.lastQuery = null;
-	
+
 			// update dropdown contents
 			if (self.isOpen) {
 				self.refreshOptions(false);
 			}
 		},
-	
+
 		/**
 		 * Removes a single option.
 		 *
@@ -9831,25 +9831,25 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		removeOption: function(value, silent) {
 			var self = this;
 			value = hash_key(value);
-	
+
 			var cache_items = self.renderCache['item'];
 			var cache_options = self.renderCache['option'];
 			if (cache_items) delete cache_items[value];
 			if (cache_options) delete cache_options[value];
-	
+
 			delete self.userOptions[value];
 			delete self.options[value];
 			self.lastQuery = null;
 			self.trigger('option_remove', value);
 			self.removeItem(value, silent);
 		},
-	
+
 		/**
 		 * Clears all options.
 		 */
 		clearOptions: function() {
 			var self = this;
-	
+
 			self.loadedSearches = {};
 			self.userOptions = {};
 			self.renderCache = {};
@@ -9858,7 +9858,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			self.trigger('option_clear');
 			self.clear();
 		},
-	
+
 		/**
 		 * Returns the jQuery element of the option
 		 * matching the given value.
@@ -9869,7 +9869,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		getOption: function(value) {
 			return this.getElementWithValue(value, this.$dropdown_content.find('[data-selectable]'));
 		},
-	
+
 		/**
 		 * Returns the jQuery element of the next or
 		 * previous selectable option.
@@ -9881,10 +9881,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		getAdjacentOption: function($option, direction) {
 			var $options = this.$dropdown.find('[data-selectable]');
 			var index    = $options.index($option) + direction;
-	
+
 			return index >= 0 && index < $options.length ? $options.eq(index) : $();
 		},
-	
+
 		/**
 		 * Finds the first element with a "data-value" attribute
 		 * that matches the given value.
@@ -9895,7 +9895,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		getElementWithValue: function(value, $els) {
 			value = hash_key(value);
-	
+
 			if (typeof value !== 'undefined' && value !== null) {
 				for (var i = 0, n = $els.length; i < n; i++) {
 					if ($els[i].getAttribute('data-value') === value) {
@@ -9903,10 +9903,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					}
 				}
 			}
-	
+
 			return $();
 		},
-	
+
 		/**
 		 * Returns the jQuery element of the item
 		 * matching the given value.
@@ -9917,7 +9917,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		getItem: function(value) {
 			return this.getElementWithValue(value, this.$control.children());
 		},
-	
+
 		/**
 		 * "Selects" multiple items at once. Adds them to the list
 		 * at the current caret position.
@@ -9932,7 +9932,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				this.addItem(items[i], silent);
 			}
 		},
-	
+
 		/**
 		 * "Selects" an item. Adds it to the list
 		 * at the current caret position.
@@ -9942,23 +9942,23 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		addItem: function(value, silent) {
 			var events = silent ? [] : ['change'];
-	
+
 			debounce_events(this, events, function() {
 				var $item, $option, $options;
 				var self = this;
 				var inputMode = self.settings.mode;
 				var i, active, value_next, wasFull;
 				value = hash_key(value);
-	
+
 				if (self.items.indexOf(value) !== -1) {
 					if (inputMode === 'single') self.close();
 					return;
 				}
-	
+
 				if (!self.options.hasOwnProperty(value)) return;
 				if (inputMode === 'single') self.clear(silent);
 				if (inputMode === 'multi' && self.isFull()) return;
-	
+
 				$item = $(self.render('item', self.options[value]));
 				wasFull = self.isFull();
 				self.items.splice(self.caretPos, 0, value);
@@ -9966,10 +9966,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				if (!self.isPending || (!wasFull && self.isFull())) {
 					self.refreshState();
 				}
-	
+
 				if (self.isSetup) {
 					$options = self.$dropdown_content.find('[data-selectable]');
-	
+
 					// update menu / remove the option (if this is not one item being added as part of series)
 					if (!self.isPending) {
 						$option = self.getOption(value);
@@ -9979,21 +9979,21 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 							self.setActiveOption(self.getOption(value_next));
 						}
 					}
-	
+
 					// hide the menu if the maximum number of items have been selected or no options are left
 					if (!$options.length || self.isFull()) {
 						self.close();
 					} else {
 						self.positionDropdown();
 					}
-	
+
 					self.updatePlaceholder();
 					self.trigger('item_add', value, $item);
 					self.updateOriginalInput({silent: silent});
 				}
 			});
 		},
-	
+
 		/**
 		 * Removes the selected item matching
 		 * the provided value.
@@ -10003,28 +10003,28 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		removeItem: function(value, silent) {
 			var self = this;
 			var $item, i, idx;
-	
+
 			$item = (value instanceof $) ? value : self.getItem(value);
 			value = hash_key($item.attr('data-value'));
 			i = self.items.indexOf(value);
-	
+
 			if (i !== -1) {
 				$item.remove();
 				if ($item.hasClass('active')) {
 					idx = self.$activeItems.indexOf($item[0]);
 					self.$activeItems.splice(idx, 1);
 				}
-	
+
 				self.items.splice(i, 1);
 				self.lastQuery = null;
 				if (!self.settings.persist && self.userOptions.hasOwnProperty(value)) {
 					self.removeOption(value, silent);
 				}
-	
+
 				if (i < self.caretPos) {
 					self.setCaret(self.caretPos - 1);
 				}
-	
+
 				self.refreshState();
 				self.updatePlaceholder();
 				self.updateOriginalInput({silent: silent});
@@ -10032,7 +10032,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.trigger('item_remove', value, $item);
 			}
 		},
-	
+
 		/**
 		 * Invokes the `create` method provided in the
 		 * selectize options that should provide the data
@@ -10050,35 +10050,35 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self  = this;
 			var caret = self.caretPos;
 			input = input || $.trim(self.$control_input.val() || '');
-	
+
 			var callback = arguments[arguments.length - 1];
 			if (typeof callback !== 'function') callback = function() {};
-	
+
 			if (typeof triggerDropdown !== 'boolean') {
 				triggerDropdown = true;
 			}
-	
+
 			if (!self.canCreate(input)) {
 				callback();
 				return false;
 			}
-	
+
 			self.lock();
-	
+
 			var setup = (typeof self.settings.create === 'function') ? this.settings.create : function(input) {
 				var data = {};
 				data[self.settings.labelField] = input;
 				data[self.settings.valueField] = input;
 				return data;
 			};
-	
+
 			var create = once(function(data) {
 				self.unlock();
-	
+
 				if (!data || typeof data !== 'object') return callback();
 				var value = hash_key(data[self.settings.valueField]);
 				if (typeof value !== 'string') return callback();
-	
+
 				self.setTextboxValue('');
 				self.addOption(data);
 				self.setCaret(caret);
@@ -10086,29 +10086,29 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.refreshOptions(triggerDropdown && self.settings.mode !== 'single');
 				callback(data);
 			});
-	
+
 			var output = setup.apply(this, [input, create]);
 			if (typeof output !== 'undefined') {
 				create(output);
 			}
-	
+
 			return true;
 		},
-	
+
 		/**
 		 * Re-renders the selected item lists.
 		 */
 		refreshItems: function() {
 			this.lastQuery = null;
-	
+
 			if (this.isSetup) {
 				this.addItem(this.items);
 			}
-	
+
 			this.refreshState();
 			this.updateOriginalInput();
 		},
-	
+
 		/**
 		 * Updates all state-dependent attributes
 		 * and CSS classes.
@@ -10117,7 +10117,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			this.refreshValidityState();
 			this.refreshClasses();
 		},
-	
+
 		/**
 		 * Update the `required` attribute of both input and control input.
 		 *
@@ -10128,14 +10128,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		refreshValidityState: function() {
 			if (!this.isRequired) return false;
-	
+
 			var invalid = !this.items.length;
-	
+
 			this.isInvalid = invalid;
 			this.$control_input.prop('required', invalid);
 			this.$input.prop('required', !invalid);
 		},
-	
+
 		/**
 		 * Updates all state-dependent CSS classes.
 		 */
@@ -10143,10 +10143,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self     = this;
 			var isFull   = self.isFull();
 			var isLocked = self.isLocked;
-	
+
 			self.$wrapper
 				.toggleClass('rtl', self.rtl);
-	
+
 			self.$control
 				.toggleClass('focus', self.isFocused)
 				.toggleClass('disabled', self.isDisabled)
@@ -10158,10 +10158,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				.toggleClass('dropdown-active', self.isOpen)
 				.toggleClass('has-options', !$.isEmptyObject(self.options))
 				.toggleClass('has-items', self.items.length > 0);
-	
+
 			self.$control_input.data('grow', !isFull && !isLocked);
 		},
-	
+
 		/**
 		 * Determines whether or not more items can be added
 		 * to the control without exceeding the user-defined maximum.
@@ -10171,7 +10171,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		isFull: function() {
 			return this.settings.maxItems !== null && this.items.length >= this.settings.maxItems;
 		},
-	
+
 		/**
 		 * Refreshes the original <select> or <input>
 		 * element to reflect the current state.
@@ -10179,7 +10179,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		updateOriginalInput: function(opts) {
 			var i, n, options, label, self = this;
 			opts = opts || {};
-	
+
 			if (self.tagType === TAG_SELECT) {
 				options = [];
 				for (i = 0, n = self.items.length; i < n; i++) {
@@ -10194,14 +10194,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.$input.val(self.getValue());
 				self.$input.attr('value',self.$input.val());
 			}
-	
+
 			if (self.isSetup) {
 				if (!opts.silent) {
 					self.trigger('change', self.$input.val());
 				}
 			}
 		},
-	
+
 		/**
 		 * Shows/hide the input placeholder depending
 		 * on if there items in the list already.
@@ -10209,7 +10209,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		updatePlaceholder: function() {
 			if (!this.settings.placeholder) return;
 			var $input = this.$control_input;
-	
+
 			if (this.items.length) {
 				$input.removeAttr('placeholder');
 			} else {
@@ -10217,14 +10217,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			$input.triggerHandler('update', {force: true});
 		},
-	
+
 		/**
 		 * Shows the autocomplete dropdown containing
 		 * the available options.
 		 */
 		open: function() {
 			var self = this;
-	
+
 			if (self.isLocked || self.isOpen || (self.settings.mode === 'multi' && self.isFull())) return;
 			self.focus();
 			self.isOpen = true;
@@ -10234,27 +10234,27 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			self.$dropdown.css({visibility: 'visible'});
 			self.trigger('dropdown_open', self.$dropdown);
 		},
-	
+
 		/**
 		 * Closes the autocomplete dropdown menu.
 		 */
 		close: function() {
 			var self = this;
 			var trigger = self.isOpen;
-	
+
 			if (self.settings.mode === 'single' && self.items.length) {
 				self.hideInput();
 				self.$control_input.blur(); // close keyboard on iOS
 			}
-	
+
 			self.isOpen = false;
 			self.$dropdown.hide();
 			self.setActiveOption(null);
 			self.refreshState();
-	
+
 			if (trigger) self.trigger('dropdown_close', self.$dropdown);
 		},
-	
+
 		/**
 		 * Calculates and applies the appropriate
 		 * position of the dropdown.
@@ -10263,14 +10263,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var $control = this.$control;
 			var offset = this.settings.dropdownParent === 'body' ? $control.offset() : $control.position();
 			offset.top += $control.outerHeight(true);
-	
+
 			this.$dropdown.css({
 				width : $control.outerWidth(),
 				top   : offset.top,
 				left  : offset.left
 			});
 		},
-	
+
 		/**
 		 * Resets / clears all selected items
 		 * from the control.
@@ -10279,7 +10279,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		clear: function(silent) {
 			var self = this;
-	
+
 			if (!self.items.length) return;
 			self.$control.children(':not(input)').remove();
 			self.items = [];
@@ -10292,7 +10292,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			self.showInput();
 			self.trigger('clear');
 		},
-	
+
 		/**
 		 * A helper method for inserting an element
 		 * at the current caret position.
@@ -10308,7 +10308,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			this.setCaret(caret + 1);
 		},
-	
+
 		/**
 		 * Removes the current selected item(s).
 		 *
@@ -10318,22 +10318,22 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		deleteSelection: function(e) {
 			var i, n, direction, selection, values, caret, option_select, $option_select, $tail;
 			var self = this;
-	
+
 			direction = (e && e.keyCode === KEY_BACKSPACE) ? -1 : 1;
 			selection = getSelection(self.$control_input[0]);
-	
+
 			if (self.$activeOption && !self.settings.hideSelected) {
 				option_select = self.getAdjacentOption(self.$activeOption, -1).attr('data-value');
 			}
-	
+
 			// determine items that will be removed
 			values = [];
-	
+
 			if (self.$activeItems.length) {
 				$tail = self.$control.children('.active:' + (direction > 0 ? 'last' : 'first'));
 				caret = self.$control.children(':not(input)').index($tail);
 				if (direction > 0) { caret++; }
-	
+
 				for (i = 0, n = self.$activeItems.length; i < n; i++) {
 					values.push($(self.$activeItems[i]).attr('data-value'));
 				}
@@ -10348,12 +10348,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					values.push(self.items[self.caretPos]);
 				}
 			}
-	
+
 			// allow the callback to abort
 			if (!values.length || (typeof self.settings.onDelete === 'function' && self.settings.onDelete.apply(self, [values]) === false)) {
 				return false;
 			}
-	
+
 			// perform removal
 			if (typeof caret !== 'undefined') {
 				self.setCaret(caret);
@@ -10361,11 +10361,11 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			while (values.length) {
 				self.removeItem(values.pop());
 			}
-	
+
 			self.showInput();
 			self.positionDropdown();
 			self.refreshOptions(true);
-	
+
 			// select previous option
 			if (option_select) {
 				$option_select = self.getOption(option_select);
@@ -10373,10 +10373,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					self.setActiveOption($option_select);
 				}
 			}
-	
+
 			return true;
 		},
-	
+
 		/**
 		 * Selects the previous / next item (depending
 		 * on the `direction` argument).
@@ -10390,19 +10390,19 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		advanceSelection: function(direction, e) {
 			var tail, selection, idx, valueLength, cursorAtEdge, $tail;
 			var self = this;
-	
+
 			if (direction === 0) return;
 			if (self.rtl) direction *= -1;
-	
+
 			tail = direction > 0 ? 'last' : 'first';
 			selection = getSelection(self.$control_input[0]);
-	
+
 			if (self.isFocused && !self.isInputHidden) {
 				valueLength = self.$control_input.val().length;
 				cursorAtEdge = direction < 0
 					? selection.start === 0 && selection.length === 0
 					: selection.start === valueLength;
-	
+
 				if (cursorAtEdge && !valueLength) {
 					self.advanceCaret(direction, e);
 				}
@@ -10415,7 +10415,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 			}
 		},
-	
+
 		/**
 		 * Moves the caret left / right.
 		 *
@@ -10424,9 +10424,9 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		advanceCaret: function(direction, e) {
 			var self = this, fn, $adj;
-	
+
 			if (direction === 0) return;
-	
+
 			fn = direction > 0 ? 'next' : 'prev';
 			if (self.isShiftDown) {
 				$adj = self.$control_input[fn]();
@@ -10439,7 +10439,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.setCaret(self.caretPos + direction);
 			}
 		},
-	
+
 		/**
 		 * Moves the caret to the specified index.
 		 *
@@ -10447,13 +10447,13 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		setCaret: function(i) {
 			var self = this;
-	
+
 			if (self.settings.mode === 'single') {
 				i = self.items.length;
 			} else {
 				i = Math.max(0, Math.min(self.items.length, i));
 			}
-	
+
 			if(!self.isPending) {
 				// the input must be moved by leaving it in place and moving the
 				// siblings, due to the fact that focus cannot be restored once lost
@@ -10469,10 +10469,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					}
 				}
 			}
-	
+
 			self.caretPos = i;
 		},
-	
+
 		/**
 		 * Disables user input on the control. Used while
 		 * items are being asynchronously created.
@@ -10482,7 +10482,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			this.isLocked = true;
 			this.refreshState();
 		},
-	
+
 		/**
 		 * Re-enables user input on the control.
 		 */
@@ -10490,7 +10490,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			this.isLocked = false;
 			this.refreshState();
 		},
-	
+
 		/**
 		 * Disables user input on the control completely.
 		 * While disabled, it cannot receive focus.
@@ -10502,7 +10502,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			self.isDisabled = true;
 			self.lock();
 		},
-	
+
 		/**
 		 * Enables the control so that it can respond
 		 * to focus and user input.
@@ -10514,7 +10514,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			self.isDisabled = false;
 			self.unlock();
 		},
-	
+
 		/**
 		 * Completely destroys the control and
 		 * unbinds all event listeners so that it can
@@ -10524,12 +10524,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var self = this;
 			var eventNS = self.eventNS;
 			var revertSettings = self.revertSettings;
-	
+
 			self.trigger('destroy');
 			self.off();
 			self.$wrapper.remove();
 			self.$dropdown.remove();
-	
+
 			self.$input
 				.html('')
 				.append(revertSettings.$children)
@@ -10537,17 +10537,17 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				.removeClass('selectized')
 				.attr({tabindex: revertSettings.tabindex})
 				.show();
-	
+
 			self.$control_input.removeData('grow');
 			self.$input.removeData('selectize');
-	
+
 			$(window).off(eventNS);
 			$(document).off(eventNS);
 			$(document.body).off(eventNS);
-	
+
 			delete self.$input[0].selectize;
 		},
-	
+
 		/**
 		 * A helper method for rendering "item" and
 		 * "option" templates, given the data.
@@ -10562,12 +10562,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var cache = false;
 			var self = this;
 			var regex_tag = /^[\t \r\n]*<([a-z][a-z0-9\-_]*(?:\:[a-z][a-z0-9\-_]*)?)/i;
-	
+
 			if (templateName === 'option' || templateName === 'item') {
 				value = hash_key(data[self.settings.valueField]);
 				cache = !!value;
 			}
-	
+
 			// pull markup from cache if it exists
 			if (cache) {
 				if (!isset(self.renderCache[templateName])) {
@@ -10577,10 +10577,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					return self.renderCache[templateName][value];
 				}
 			}
-	
+
 			// render markup
 			html = $(self.settings.render[templateName].apply(this, [data, escape_html]));
-	
+
 			// add mandatory attributes
 			if (templateName === 'option' || templateName === 'option_create') {
 				html.attr('data-selectable', '');
@@ -10592,15 +10592,15 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			if (templateName === 'option' || templateName === 'item') {
 				html.attr('data-value', value || '');
 			}
-	
+
 			// update cache
 			if (cache) {
 				self.renderCache[templateName][value] = html[0];
 			}
-	
+
 			return html[0];
 		},
-	
+
 		/**
 		 * Clears the render cache for a template. If
 		 * no template is given, clears all render
@@ -10616,7 +10616,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				delete self.renderCache[templateName];
 			}
 		},
-	
+
 		/**
 		 * Determines whether or not to display the
 		 * create item prompt, given a user input.
@@ -10633,15 +10633,15 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				&& (typeof filter !== 'string' || new RegExp(filter).test(input))
 				&& (!(filter instanceof RegExp) || filter.test(input));
 		}
-	
+
 	});
-	
-	
+
+
 	Selectize.count = 0;
 	Selectize.defaults = {
 		options: [],
 		optgroups: [],
-	
+
 		plugins: [],
 		delimiter: ',',
 		splitOn: null, // regexp or string for splitting up values from a paste command
@@ -10660,11 +10660,11 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		preload: false,
 		allowEmptyOption: false,
 		closeAfterSelect: false,
-	
+
 		scrollDuration: 60,
 		loadThrottle: 300,
 		loadingClass: 'loading',
-	
+
 		dataAttr: 'data-data',
 		optgroupField: 'optgroup',
 		valueField: 'value',
@@ -10672,21 +10672,21 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		optgroupLabelField: 'label',
 		optgroupValueField: 'value',
 		lockOptgroupOrder: false,
-	
+
 		sortField: '$order',
 		searchField: ['text'],
 		searchConjunction: 'and',
-	
+
 		mode: null,
 		wrapperClass: 'selectize-control',
 		inputClass: 'selectize-input',
 		dropdownClass: 'selectize-dropdown',
 		dropdownContentClass: 'selectize-dropdown-content',
-	
+
 		dropdownParent: null,
-	
+
 		copyClassesToDropdown: true,
-	
+
 		/*
 		load                 : null, // function(query, callback) { ... }
 		score                : null, // function(search) { ... }
@@ -10706,7 +10706,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		onType               : null, // function(str) { ... }
 		onDelete             : null, // function(values) { ... }
 		*/
-	
+
 		render: {
 			/*
 			item: null,
@@ -10717,8 +10717,8 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			*/
 		}
 	};
-	
-	
+
+
 	$.fn.selectize = function(settings_user) {
 		var defaults             = $.fn.selectize.defaults;
 		var settings             = $.extend({}, defaults, settings_user);
@@ -10728,7 +10728,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		var field_optgroup       = settings.optgroupField;
 		var field_optgroup_label = settings.optgroupLabelField;
 		var field_optgroup_value = settings.optgroupValueField;
-	
+
 		/**
 		 * Initializes selectize from a <input type="text"> element.
 		 *
@@ -10737,9 +10737,9 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 		 */
 		var init_textbox = function($input, settings_element) {
 			var i, n, values, option;
-	
+
 			var data_raw = $input.attr(attr_data);
-	
+
 			if (!data_raw) {
 				var value = $.trim($input.val() || '');
 				if (!settings.allowEmptyOption && !value.length) return;
@@ -10758,7 +10758,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 			}
 		};
-	
+
 		/**
 		 * Initializes selectize from a <select> element.
 		 *
@@ -10769,7 +10769,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			var i, n, tagName, $children, order = 0;
 			var options = settings_element.options;
 			var optionsMap = {};
-	
+
 			var readData = function($el) {
 				var data = attr_data && $el.attr(attr_data);
 				if (typeof data === 'string' && data.length) {
@@ -10777,13 +10777,13 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 				return null;
 			};
-	
+
 			var addOption = function($option, group) {
 				$option = $($option);
-	
+
 				var value = hash_key($option.val());
 				if (!value && !settings.allowEmptyOption) return;
-	
+
 				// if the option already exists, it's probably been
 				// duplicated in another optgroup. in this case, push
 				// the current group to the "optgroup" property on the
@@ -10801,41 +10801,41 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					}
 					return;
 				}
-	
+
 				var option             = readData($option) || {};
 				option[field_label]    = option[field_label] || $option.text();
 				option[field_value]    = option[field_value] || value;
 				option[field_optgroup] = option[field_optgroup] || group;
-	
+
 				optionsMap[value] = option;
 				options.push(option);
-	
+
 				if ($option.is(':selected')) {
 					settings_element.items.push(value);
 				}
 			};
-	
+
 			var addGroup = function($optgroup) {
 				var i, n, id, optgroup, $options;
-	
+
 				$optgroup = $($optgroup);
 				id = $optgroup.attr('label');
-	
+
 				if (id) {
 					optgroup = readData($optgroup) || {};
 					optgroup[field_optgroup_label] = id;
 					optgroup[field_optgroup_value] = id;
 					settings_element.optgroups.push(optgroup);
 				}
-	
+
 				$options = $('option', $optgroup);
 				for (i = 0, n = $options.length; i < n; i++) {
 					addOption($options[i], id);
 				}
 			};
-	
+
 			settings_element.maxItems = $input.attr('multiple') ? null : 1;
-	
+
 			$children = $input.children();
 			for (i = 0, n = $children.length; i < n; i++) {
 				tagName = $children[i].tagName.toLowerCase();
@@ -10846,10 +10846,10 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 			}
 		};
-	
+
 		return this.each(function() {
 			if (this.selectize) return;
-	
+
 			var instance;
 			var $input = $(this);
 			var tag_name = this.tagName.toLowerCase();
@@ -10857,35 +10857,35 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			if (!placeholder && !settings.allowEmptyOption) {
 				placeholder = $input.children('option[value=""]').text();
 			}
-	
+
 			var settings_element = {
 				'placeholder' : placeholder,
 				'options'     : [],
 				'optgroups'   : [],
 				'items'       : []
 			};
-	
+
 			if (tag_name === 'select') {
 				init_select($input, settings_element);
 			} else {
 				init_textbox($input, settings_element);
 			}
-	
+
 			instance = new Selectize($input, $.extend(true, {}, defaults, settings_element, settings_user));
 		});
 	};
-	
+
 	$.fn.selectize.defaults = Selectize.defaults;
 	$.fn.selectize.support = {
 		validity: SUPPORTS_VALIDITY_API
 	};
-	
-	
+
+
 	Selectize.define('drag_drop', function(options) {
 		if (!$.fn.sortable) throw new Error('The "drag_drop" plugin requires jQuery UI "sortable".');
 		if (this.settings.mode !== 'multi') return;
 		var self = this;
-	
+
 		self.lock = (function() {
 			var original = self.lock;
 			return function() {
@@ -10894,7 +10894,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				return original.apply(self, arguments);
 			};
 		})();
-	
+
 		self.unlock = (function() {
 			var original = self.unlock;
 			return function() {
@@ -10903,12 +10903,12 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				return original.apply(self, arguments);
 			};
 		})();
-	
+
 		self.setup = (function() {
 			var original = self.setup;
 			return function() {
 				original.apply(this, arguments);
-	
+
 				var $control = self.$control.sortable({
 					items: '[data-value]',
 					forcePlaceholderSize: true,
@@ -10930,19 +10930,19 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				});
 			};
 		})();
-	
+
 	});
-	
+
 	Selectize.define('dropdown_header', function(options) {
 		var self = this;
-	
+
 		options = $.extend({
 			title         : 'Untitled',
 			headerClass   : 'selectize-dropdown-header',
 			titleRowClass : 'selectize-dropdown-header-title',
 			labelClass    : 'selectize-dropdown-header-label',
 			closeClass    : 'selectize-dropdown-header-close',
-	
+
 			html: function(data) {
 				return (
 					'<div class="' + data.headerClass + '">' +
@@ -10954,7 +10954,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				);
 			}
 		}, options);
-	
+
 		self.setup = (function() {
 			var original = self.setup;
 			return function() {
@@ -10963,40 +10963,40 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				self.$dropdown.prepend(self.$dropdown_header);
 			};
 		})();
-	
+
 	});
-	
+
 	Selectize.define('optgroup_columns', function(options) {
 		var self = this;
-	
+
 		options = $.extend({
 			equalizeWidth  : true,
 			equalizeHeight : true
 		}, options);
-	
+
 		this.getAdjacentOption = function($option, direction) {
 			var $options = $option.closest('[data-group]').find('[data-selectable]');
 			var index    = $options.index($option) + direction;
-	
+
 			return index >= 0 && index < $options.length ? $options.eq(index) : $();
 		};
-	
+
 		this.onKeyDown = (function() {
 			var original = self.onKeyDown;
 			return function(e) {
 				var index, $option, $options, $optgroup;
-	
+
 				if (this.isOpen && (e.keyCode === KEY_LEFT || e.keyCode === KEY_RIGHT)) {
 					self.ignoreHover = true;
 					$optgroup = this.$activeOption.closest('[data-group]');
 					index = $optgroup.find('[data-selectable]').index(this.$activeOption);
-	
+
 					if(e.keyCode === KEY_LEFT) {
 						$optgroup = $optgroup.prev('[data-group]');
 					} else {
 						$optgroup = $optgroup.next('[data-group]');
 					}
-	
+
 					$options = $optgroup.find('[data-selectable]');
 					$option  = $options.eq(Math.min($options.length - 1, index));
 					if ($option.length) {
@@ -11004,16 +11004,16 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					}
 					return;
 				}
-	
+
 				return original.apply(this, arguments);
 			};
 		})();
-	
+
 		var getScrollbarWidth = function() {
 			var div;
 			var width = getScrollbarWidth.width;
 			var doc = document;
-	
+
 			if (typeof width === 'undefined') {
 				div = doc.createElement('div');
 				div.innerHTML = '<div style="width:50px;height:50px;position:absolute;left:-50px;top:-50px;overflow:auto;"><div style="width:1px;height:100px;"></div></div>';
@@ -11024,14 +11024,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			}
 			return width;
 		};
-	
+
 		var equalizeSizes = function() {
 			var i, n, height_max, width, width_last, width_parent, $optgroups;
-	
+
 			$optgroups = $('[data-group]', self.$dropdown_content);
 			n = $optgroups.length;
 			if (!n || !self.$dropdown_content.width()) return;
-	
+
 			if (options.equalizeHeight) {
 				height_max = 0;
 				for (i = 0; i < n; i++) {
@@ -11039,7 +11039,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 				$optgroups.css({height: height_max});
 			}
-	
+
 			if (options.equalizeWidth) {
 				width_parent = self.$dropdown_content.innerWidth() - getScrollbarWidth();
 				width = Math.round(width_parent / n);
@@ -11050,15 +11050,15 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				}
 			}
 		};
-	
+
 		if (options.equalizeHeight || options.equalizeWidth) {
 			hook.after(this, 'positionDropdown', equalizeSizes);
 			hook.after(this, 'refreshOptions', equalizeSizes);
 		}
-	
-	
+
+
 	});
-	
+
 	Selectize.define('remove_button', function(options) {
 		options = $.extend({
 				label     : '&times;',
@@ -11066,14 +11066,14 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				className : 'remove',
 				append    : true
 			}, options);
-	
+
 			var singleClose = function(thisRef, options) {
-	
+
 				options.className = 'remove-single';
-	
+
 				var self = thisRef;
 				var html = '<a href="javascript:void(0)" class="' + options.className + '" tabindex="-1" title="' + escape_html(options.title) + '">' + options.label + '</a>';
-	
+
 				/**
 				 * Appends an element as a child (with raw HTML).
 				 *
@@ -11084,7 +11084,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				var append = function(html_container, html_element) {
 					return html_container + html_element;
 				};
-	
+
 				thisRef.setup = (function() {
 					var original = self.setup;
 					return function() {
@@ -11092,32 +11092,32 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 						if (options.append) {
 							var id = $(self.$input.context).attr('id');
 							var selectizer = $('#'+id);
-	
+
 							var render_item = self.settings.render.item;
 							self.settings.render.item = function(data) {
 								return append(render_item.apply(thisRef, arguments), html);
 							};
 						}
-	
+
 						original.apply(thisRef, arguments);
-	
+
 						// add event listener
 						thisRef.$control.on('click', '.' + options.className, function(e) {
 							e.preventDefault();
 							if (self.isLocked) return;
-	
+
 							self.clear();
 						});
-	
+
 					};
 				})();
 			};
-	
+
 			var multiClose = function(thisRef, options) {
-	
+
 				var self = thisRef;
 				var html = '<a href="javascript:void(0)" class="' + options.className + '" tabindex="-1" title="' + escape_html(options.title) + '">' + options.label + '</a>';
-	
+
 				/**
 				 * Appends an element as a child (with raw HTML).
 				 *
@@ -11129,7 +11129,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 					var pos = html_container.search(/(<\/[^>]+>\s*)$/);
 					return html_container.substring(0, pos) + html_element + html_container.substring(pos);
 				};
-	
+
 				thisRef.setup = (function() {
 					var original = self.setup;
 					return function() {
@@ -11140,25 +11140,25 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 								return append(render_item.apply(thisRef, arguments), html);
 							};
 						}
-	
+
 						original.apply(thisRef, arguments);
-	
+
 						// add event listener
 						thisRef.$control.on('click', '.' + options.className, function(e) {
 							e.preventDefault();
 							if (self.isLocked) return;
-	
+
 							var $item = $(e.currentTarget).parent();
 							self.setActiveItem($item);
 							if (self.deleteSelection()) {
 								self.setCaret(self.items.length);
 							}
 						});
-	
+
 					};
 				})();
 			};
-	
+
 			if (this.settings.mode === 'single') {
 				singleClose(this, options);
 				return;
@@ -11166,15 +11166,15 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 				multiClose(this, options);
 			}
 	});
-	
-	
+
+
 	Selectize.define('restore_on_backspace', function(options) {
 		var self = this;
-	
+
 		options.text = options.text || function(option) {
 			return option[this.settings.labelField];
 		};
-	
+
 		this.onKeyDown = (function() {
 			var original = self.onKeyDown;
 			return function(e) {
@@ -11195,7 +11195,7 @@ if (window.Sweetalert2) window.sweetAlert = window.swal = window.Sweetalert2;
 			};
 		})();
 	});
-	
+
 
 	return Selectize;
 }));

--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -475,13 +475,13 @@ class WeForms_Notification {
      * and {value:department} to get support@email.com
      *
      * @param string $text The text to parse.
-     * @param int    $entry_id The entry ID.
+     * @param int    $entry_id The entry ID. Optional. Default null if tags to be replaced are on the frontend.
      *
      * @return string  $text The parsed text.
      */
-    public static function replace_field_tags( $text, $entry_id ) {
+    public static function replace_field_tags( $text, $entry_id = null ) {
         // Validate data.
-        if ( empty( $text ) || empty( $entry_id ) ) {
+        if ( empty( $text ) || !isset( $entry_id ) ) {
             return;
         }
 


### PR DESCRIPTION
Fixes issue #149  with placeholder text being replaced with a blank value.

also fixes https://github.com/BoldGrid/weforms-pro/issues/89.

replace tag runs on both notifications and front-end rendering. When rendering on the front end there is no entry id, unlike with notifications from an entry.

To test:
Create a form with placeholder text on name field or textarea field
ensure placeholder shows on frontend.