### PR TITLE
Add validation for entry_fields filter

### DIFF
--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -761,26 +761,34 @@ class WeForms_Ajax {
 
         $entry_fields = apply_filters( 'weforms_before_entry_submission', $entry_fields, $form, $form_settings, $form_fields );
 
-        $entry_id = 1;
-        $global_settings = weforms_get_settings();
-        if ( empty( $form_settings['after_submission'] ) ) {
-            $entry_id = weforms_insert_entry( [
-                'form_id' => $form_id,
-            ], $entry_fields );
-            if ( is_wp_error( $entry_id ) ) {
-                wp_send_json( [
-                    'success' => false,
-                    'error'   => $entry_id->get_error_message(),
-                ] );
-            }
-            // Fire a hook for integration
-            do_action( 'weforms_entry_submission', $entry_id, $form_id, $page_id, $form_settings );
-            $notification = new WeForms_Notification( [
-                'form_id'  => $form_id,
-                'page_id'  => $page_id,
-                'entry_id' => $entry_id,
+        //check for entry_fields for a return error
+        if ( is_wp_error( $entry_fields ) ) {
+            wp_send_json( [
+                'success' => false,
+                'error'   => $entry_fields->get_error_message(),
             ] );
-            $notification->send_notifications();
+        } else {
+            $entry_id = 1;
+            $global_settings = weforms_get_settings();
+            if ( empty( $form_settings['after_submission'] ) ) {
+                $entry_id = weforms_insert_entry( [
+                    'form_id' => $form_id,
+                ], $entry_fields );
+                if ( is_wp_error( $entry_id ) ) {
+                    wp_send_json( [
+                        'success' => false,
+                        'error'   => $entry_id->get_error_message(),
+                    ] );
+                }
+                // Fire a hook for integration
+                do_action( 'weforms_entry_submission', $entry_id, $form_id, $page_id, $form_settings );
+                $notification = new WeForms_Notification( [
+                    'form_id'  => $form_id,
+                    'page_id'  => $page_id,
+                    'entry_id' => $entry_id,
+                ] );
+                $notification->send_notifications();
+            }
         }
         // redirect URL
         $show_message = false;


### PR DESCRIPTION
Not able to filter the hook in weForms "weforms_before_entry_submission"
Name | Check for return
Reporter | Elana D.
Submit Date | 6/14/2022
Summary | when you hook into entry submission there isn't any check to check if there was an error.


https://github.com/BoldGrid/weforms/issues/167