### PR TITLE
fixes #194 Array Key "name" doesnt exist for custom html field

### DIFF
--- a/includes/fields/class-field-html.php
+++ b/includes/fields/class-field-html.php
@@ -20,6 +20,14 @@ class WeForms_Form_Field_HTML extends WeForms_Field_Contract {
      * @return void
      */
     public function render( $field_settings, $form_id ) {
+        /**
+         * Ensure the field name is set. There have been cases where the name array key is not set.
+         * Not sure why and we were unable to replicate without manually removing the key.
+         * This is a failsafe to ensure the field name is set.
+         */
+        if ( ! isset( $field_settings['name'] ) ) {
+            $field_settings['name'] = 'custom_html';
+        }
         $use_theme_css    = isset( $form_settings['use_theme_css'] ) ? $form_settings['use_theme_css'] : 'wpuf-style';
         ?>
         <li <?php $this->print_list_attributes( $field_settings ); ?>>

--- a/readme.txt
+++ b/readme.txt
@@ -237,7 +237,7 @@ weForms is the most beginner friendly and fastest WordPress contact form plugin 
 
 == Changelog ==
 
-= Version 1.6.16 ( TBD ) =
+= Version 1.6.16 ( 12 December, 2022 ) =
 * **Fix:** Empty field entries ending form entries view script.
 * **Fix:** Missing html tag on textarea field.
 


### PR DESCRIPTION
Fixes #194

### Testing

This is an edge case, and we could not find what was causing it based on what was provided on the support ticket.
The only way to replicate it was to unset the array key. This should not happen in normal operations.

Logic has been added to ensure that the array key will always exist on render.
