### PR TITLE
Fixes contrast for form white text error messages

### DIFF
--- a/assets/wpuf/css/frontend-forms.css
+++ b/assets/wpuf/css/frontend-forms.css
@@ -3,43 +3,53 @@
   display: table;
   width: 100%;
 }
+
 .wpufTableRow {
   display: table-row;
 }
+
 .wpufTableRow:nth-child(even) {
   background-color: #f5f5f5;
 }
+
 .wpufTableHeading {
   background-color: #eee;
   display: table-header-group;
   font-weight: bold;
 }
+
 .wpufTableCell,
 .wpufTableHead {
   border: none;
   display: table-cell;
   padding: 3px 10px;
 }
+
 .wpufTableFoot {
   background-color: #eee;
   display: table-footer-group;
   font-weight: bold;
 }
+
 .wpufTableBody {
   display: table-row-group;
 }
+
 .wpuf-menu-item.active a {
   color: #040202;
 }
+
 .wpuf-loading {
   width: 16px;
   height: 16px;
   background: url('../images/wpspin_light.gif') no-repeat;
   display: inline-block;
 }
+
 .wpuf-loading.hide {
   display: none;
 }
+
 .wpuf-button {
   color: #555;
   border-color: #cccccc;
@@ -48,12 +58,14 @@
   box-shadow: 0 1px 0 #cccccc;
   vertical-align: top;
 }
+
 .wpuf-button:hover,
 .wpuf-button:focus {
   background: #fafafa;
   border-color: #999;
   color: #23282d;
 }
+
 .wpuf-success {
   background-color: #dff0d8;
   border: 1px solid #d6e9c6;
@@ -61,6 +73,7 @@
   padding: 10px;
   margin: 10px 0 20px 0;
 }
+
 .wpuf-error {
   background-color: #f2dede;
   color: #a94442;
@@ -72,6 +85,7 @@
   border-radius: 3px;
   font-size: 13px;
 }
+
 .wpuf-message {
   background: #fcf8e3;
   border: 1px solid #faebcc;
@@ -83,14 +97,17 @@
   border-radius: 3px;
   font-size: 13px;
 }
+
 #wpuf-private-message .chat-box {
   margin-bottom: 30px;
 }
+
 #wpuf-private-message .write-area {
   width: 100%;
   border-radius: 4px;
   margin-bottom: 10px;
 }
+
 .wpuf-info {
   background-color: #fef5be;
   border: 2px solid #fdd425;
@@ -101,6 +118,7 @@
   margin: 0 0 10px 0;
   font-size: 13px;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields input[type=text],
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields input[type=text],
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields input[type=password],
@@ -123,6 +141,7 @@
   color: #888;
   width: 95%;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields input[type=text]:focus,
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields input[type=text]:focus,
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields input[type=password]:focus,
@@ -137,11 +156,13 @@
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields textarea:focus {
   color: #373737;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields textarea,
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields textarea {
   padding-left: 3px;
   width: 95%;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields input[type=text],
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields input[type=text],
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields input[type=password],
@@ -154,6 +175,7 @@
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields input[type=number] {
   padding: 5px;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields select,
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields select {
   border: 1px solid #eee;
@@ -165,10 +187,12 @@
   min-width: 150px;
   max-width: 100%;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-fields select[multiple],
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-fields select[multiple] {
   height: auto;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-submit input[type=submit],
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-submit input[type=submit] {
   font-size: 16px;
@@ -187,6 +211,7 @@
   text-decoration: none;
   text-shadow: 0 -1px 1px #006799, 1px 0 1px #006799, 0 1px 1px #006799, -1px 0 1px #006799;
 }
+
 #form-preview-stage.wpuf-style ul.wpuf-form .wpuf-submit input[type=submit]:disabled,
 .wpuf-form-add.wpuf-style ul.wpuf-form .wpuf-submit input[type=submit]:disabled {
   background: #dddddd;
@@ -196,66 +221,81 @@
   color: #000;
   text-shadow: 0 -1px 1px #dddddd, 1px 0 1px #dddddd, 0 1px 1px #dddddd, -1px 0 1px #dddddd;
 }
+
 ul.wpuf-form {
   list-style: none !important;
   margin: 0 !important;
   padding: 0 !important;
   width: 100%;
 }
+
 ul.wpuf-form li {
   margin-left: 0;
   margin-bottom: 10px;
   padding: 10px;
 }
+
 ul.wpuf-form li:after {
   clear: both;
   content: "";
   display: table;
 }
+
 ul.wpuf-form li.has-error {
   background: #FFE4E4;
 }
+
 ul.wpuf-form li .wp-editor-wrap {
   border: 1px solid #eee;
 }
+
 ul.wpuf-form li.wpuf_hidden_field {
   display: none;
 }
+
 ul.wpuf-form li .wpuf-label {
   float: left;
   width: 30%;
   min-height: 1px;
   font-weight: bold;
 }
+
 ul.wpuf-form li .wpuf-label .required {
   color: red;
 }
+
 ul.wpuf-form li.field-size-large .wpuf-fields {
   float: left;
   width: 70%;
 }
+
 ul.wpuf-form li.field-size-medium .wpuf-fields {
   float: left;
   width: 50%;
 }
+
 ul.wpuf-form li.field-size-small .wpuf-fields {
   float: left;
   width: 30%;
 }
+
 ul.wpuf-form li .wpuf-fields {
   float: left;
   width: 70%;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-radio-inline,
 ul.wpuf-form li .wpuf-fields .wpuf-checkbox-inline {
   display: inline-block;
   margin-right: 10px;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-radio-block,
 ul.wpuf-form li .wpuf-fields .wpuf-checkbox-block {
   display: block;
   margin-bottom: 6px;
 }
+
 ul.wpuf-form li .wpuf-fields a.file-selector {
   display: inline;
   text-decoration: none;
@@ -274,57 +314,71 @@ ul.wpuf-form li .wpuf-fields a.file-selector {
   -webkit-appearance: none;
   white-space: nowrap;
 }
+
 ul.wpuf-form li .wpuf-fields a.file-selector:hover,
 ul.wpuf-form li .wpuf-fields a.file-selector:focus {
   background: #fafafa;
   border-color: #999;
   color: #23282d;
 }
+
 ul.wpuf-form li .wpuf-fields .google-map img {
   max-width: none !important;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-product-qty {
   float: left;
   width: 10%;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap {
   margin-bottom: 8px;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap:after {
   clear: both;
   content: "";
   display: table;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-last .wpuf-name-field-first-name {
   float: left;
   width: 48%;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-last .wpuf-name-field-middle-name {
   display: none;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-last .wpuf-name-field-last-name {
   float: right;
   width: 48%;
 }
+
 @media (max-width: 767px) {
+
   ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-last .wpuf-name-field-last-name,
   ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-last .wpuf-name-field-first-name {
     width: 100%;
   }
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-middle-last .wpuf-name-field-first-name {
   float: left;
   width: 37%;
   margin-right: 3%;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-middle-last .wpuf-name-field-middle-name {
   float: left;
   width: 20%;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-name-field-wrap.format-first-middle-last .wpuf-name-field-last-name {
   float: right;
   width: 37%;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-help {
   color: #666;
   margin: 2px 0 5px 0;
@@ -333,25 +387,31 @@ ul.wpuf-form li .wpuf-fields .wpuf-help {
   font-family: sans-serif;
   display: block;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-help .text-danger {
   color: red;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-help .text-success {
   color: green;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-help #url-alart,
 ul.wpuf-form li .wpuf-fields .wpuf-help #url-alart-mgs {
   font-style: normal;
   font-size: 16px;
 }
+
 ul.wpuf-form li .wpuf-fields table,
 ul.wpuf-form li .wpuf-fields td {
   border: none;
   margin: 0;
 }
+
 ul.wpuf-form li .wpuf-fields table {
   width: 100%;
 }
+
 ul.wpuf-form li .wpuf-fields img.wpuf-clone-field,
 ul.wpuf-form li .wpuf-fields img.wpuf-remove-field {
   cursor: pointer;
@@ -359,11 +419,13 @@ ul.wpuf-form li .wpuf-fields img.wpuf-remove-field {
   box-shadow: none;
   border: none;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list {
   list-style: none;
   margin: 5px 0 0 0;
   padding: 0;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list li {
   display: inline-block;
   border: 1px solid #eee;
@@ -375,18 +437,22 @@ ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list li {
   -moz-border-radius: 5px;
   border-radius: 5px;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list li .wpuf-file-input-wrap {
   margin: 10px 0;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list li .wpuf-file-input-wrap input,
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list li .wpuf-file-input-wrap textarea {
   border: 1px solid #eee;
   width: 93%;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list li .attachment-name {
   text-align: center;
   line-height: 0;
 }
+
 ul.wpuf-form li .wpuf-fields .progress {
   background: -moz-linear-gradient(center bottom, #FFFFFF 0%, #F7F7F7 100%) repeat scroll 0 0 #FFFFFF;
   border: 1px solid #D1D1D1;
@@ -400,6 +466,7 @@ ul.wpuf-form li .wpuf-fields .progress {
   padding: 0;
   width: 200px;
 }
+
 ul.wpuf-form li .wpuf-fields .bar {
   background-color: #83B4D8;
   background-image: -moz-linear-gradient(center bottom, #72A7CF 0%, #90C5EE 100%);
@@ -409,6 +476,7 @@ ul.wpuf-form li .wpuf-fields .bar {
   width: 0;
   z-index: 9;
 }
+
 ul.wpuf-form li .wpuf-fields .progress .percent {
   color: rgba(0, 0, 0, 0.6);
   padding: 0 8px;
@@ -417,27 +485,33 @@ ul.wpuf-form li .wpuf-fields .progress .percent {
   width: 200px;
   z-index: 10;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-category-checklist {
   list-style: none;
   margin: 0;
   padding: 0;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-category-checklist li {
   margin-bottom: 5px;
   padding: 0;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-category-checklist ul.children {
   list-style: none;
   margin-left: 25px;
 }
+
 ul.wpuf-form li .wpuf-fields #wpuf-insert-image-container {
   margin-bottom: 3px;
 }
+
 ul.wpuf-form li .wpuf-fields #wpuf-insert-image-container:after {
   clear: both;
   content: "";
   display: table;
 }
+
 ul.wpuf-form li .wpuf-fields #wpuf-insert-image-container a.wpuf-insert-image {
   text-decoration: none;
   border: 1px solid #DFDFDF;
@@ -448,65 +522,80 @@ ul.wpuf-form li .wpuf-fields #wpuf-insert-image-container a.wpuf-insert-image {
   padding: 4px 6px;
   margin-right: 10px;
 }
+
 ul.wpuf-form li .wpuf-fields #wpuf-insert-image-container a.wpuf-insert-image .wpuf-media-icon {
   height: 12px;
   width: 12px;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-fields-list {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
   list-style: none;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-fields-list li {
   padding: 0;
   margin: 0 0 6px;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-fields-list.wpuf-list-inline {
   margin-left: -5px;
 }
+
 ul.wpuf-form li .wpuf-fields .wpuf-fields-list.wpuf-list-inline li {
   display: inline-block;
   padding-left: 5px;
   padding-right: 5px;
 }
+
 ul.wpuf-form li .wpuf-fields table.wpuf-repeatable-field {
   border-collapse: collapse;
 }
+
 ul.wpuf-form li .wpuf-fields table.wpuf-repeatable-field * {
   box-sizing: border-box;
 }
+
 ul.wpuf-form li .wpuf-fields table.wpuf-repeatable-field input {
   width: 100%;
 }
+
 ul.wpuf-form li .wpuf-fields table.wpuf-repeatable-field .wpuf-repeater-buttons {
   width: 75px;
   padding-left: 12px;
 }
+
 ul.wpuf-form li .wpuf-fields table.wpuf-repeatable-field .wpuf-repeater-buttons img {
   width: 100%;
   height: auto;
 }
+
 ul.wpuf-form li .wpuf-fields table.wpuf-repeatable-field .wpuf-repeater-buttons i {
   display: inline-block;
   width: 15px;
   height: 15px;
   margin: 2px 4px 0 0;
 }
+
 ul.wpuf-form li label.wpuf-form-sub-label {
   font-size: 12px;
   display: inline-block;
   padding-top: 5px;
 }
+
 ul.wpuf-form li .wpuf-address-field {
   width: 100%;
   margin-bottom: 10px;
 }
+
 ul.wpuf-form li .wpuf-address-field:after {
   clear: both;
   content: "";
   display: table;
 }
+
 ul.wpuf-form li .wpuf-address-field.city_name,
 ul.wpuf-form li .wpuf-address-field.state,
 ul.wpuf-form li .wpuf-address-field.zip,
@@ -514,74 +603,91 @@ ul.wpuf-form li .wpuf-address-field.country_select {
   float: left;
   width: 47%;
 }
+
 ul.wpuf-form li .wpuf-address-field.city_name,
 ul.wpuf-form li .wpuf-address-field.zip {
   margin-right: 4%;
 }
+
 ul.wpuf-form li .wpuf-address-field.zip {
   clear: both;
 }
+
 ul.wpuf-form li .wpuf-section-wrap {
   border-bottom: 1px solid #ccc;
   margin: 15px 0;
 }
+
 ul.wpuf-form li .wpuf-section-wrap h2.wpuf-section-title {
   margin: 0;
 }
+
 ul.wpuf-form li .wpuf-section-wrap .wpuf-section-details {
   padding: 4px 0 8px;
   font-size: 12px;
 }
+
 ul.wpuf-form.form-label-above li .wpuf-label,
 ul.wpuf-form.form-label-above li .wpuf-fields {
   display: block;
   float: none;
   width: 100%;
 }
+
 ul.wpuf-form.form-label-above li.field-size-large .wpuf-fields {
   display: block;
   float: none;
   width: 100%;
 }
+
 ul.wpuf-form.form-label-above li.field-size-medium .wpuf-fields {
   display: block;
   float: none;
   width: 65%;
 }
+
 ul.wpuf-form.form-label-above li.field-size-small .wpuf-fields {
   display: block;
   float: none;
   width: 30%;
 }
+
 ul.wpuf-form.form-label-above li .wpuf-label {
   margin-bottom: 10px;
 }
+
 ul.wpuf-form.form-label-right li .wpuf-label {
   float: right;
 }
+
 ul.wpuf-form.form-label-hidden li .wpuf-label {
   display: none;
 }
+
 ul.wpuf-form.form-label-hidden li.field-size-large .wpuf-fields {
   display: block;
   float: none;
   width: 100%;
 }
+
 ul.wpuf-form.form-label-hidden li.field-size-medium .wpuf-fields {
   display: block;
   float: none;
   width: 65%;
 }
+
 ul.wpuf-form.form-label-hidden li.field-size-small .wpuf-fields {
   display: block;
   float: none;
   width: 30%;
 }
+
 ul.wpuf-form.form-label-hidden li .wpuf-fields {
   display: block;
   float: none;
   width: 100%;
 }
+
 ul.wpuf-form .wpuf-submit .button-primary-disabled {
   color: #94cde7 !important;
   background: #298cba !important;
@@ -591,9 +697,11 @@ ul.wpuf-form .wpuf-submit .button-primary-disabled {
   text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.1) !important;
   cursor: default;
 }
+
 ul.wpuf-form .wpuf-submit .wpuf-errors {
   background: #FFE4E4;
   border: 1px solid #ffb1b1;
+  color: #333333 !important;
   margin: 10px 0;
   padding: 10px;
   -webkit-border-radius: 3px;
@@ -601,43 +709,57 @@ ul.wpuf-form .wpuf-submit .wpuf-errors {
   border-radius: 3px;
   font-size: 13px;
 }
+
+li.has-error {
+  color: #333333;
+}
+
 ul.wpuf-form:not(.form-label-left) .wpuf-submit .wpuf-label {
   display: none !important;
 }
+
 #wpuf-login-form label {
   display: block;
 }
+
 #wpuf-login-form .forgetmenot label {
   display: inline-block;
 }
+
 .wpuf_sub_info {
   padding: 0;
   margin: 10px 5px;
   border: 1px solid #eee;
   border-radius: 3px;
 }
+
 .wpuf_sub_info h3 {
   background-color: #f1f1f1;
   padding: 10px;
   margin: 0 0 5px 0 !important;
   font-weight: 300 !important;
 }
+
 .wpuf_sub_info .wpuf-text {
   padding: 5px 10px;
 }
+
 .wpuf_sub_info .wpuf-expire {
   border-top: 1px solid #eee;
   padding-top: 5px;
   margin-top: 5px;
 }
+
 .wpuf-coupon-info-wrap {
   border: 1px solid #eee;
   padding: 15px;
   margin-bottom: 20px;
 }
+
 .wpuf-coupon-info-wrap .wpuf-coupon-field-spinner {
   background: url('../images/wpspin_light.gif') no-repeat right scroll rgba(0, 0, 0, 0);
 }
+
 .wpuf-coupon-info-wrap .wpuf-copon-show {
   background: #EEEEEE;
   border-radius: 3px;
@@ -652,17 +774,21 @@ ul.wpuf-form:not(.form-label-left) .wpuf-submit .wpuf-label {
   width: 175px;
   margin-bottom: 8px;
 }
+
 .wpuf-coupon-info-wrap .wpuf-copon-wrap {
   margin: 15px 0;
 }
+
 .wpuf-coupon-info-wrap .wpuf-pack-info {
   margin-bottom: 20px;
 }
+
 .wpuf-coupon-info-wrap .wpuf-pack-info h3 {
   margin: 0 0 10px 0;
   padding: 0 0 10px 0;
   border-bottom: 1px solid #eee;
 }
+
 .wpuf-coupon-info-wrap .wpuf-pack-info h3 a {
   text-decoration: none;
   background: #64C3DE;
@@ -670,15 +796,18 @@ ul.wpuf-form:not(.form-label-left) .wpuf-submit .wpuf-label {
   padding: 3px 8px;
   font-size: 14px;
 }
+
 .wpuf-coupon-info-wrap .wpuf-pack-info wpuf-subscription-error {
   color: #D8000C;
 }
+
 .wpuf-coupon-info-wrap .wpuf-copon-show:hover {
   background: none repeat scroll 0 0 #1E8CBE;
   border-color: #0074A2;
   box-shadow: 0 1px 0 rgba(120, 200, 230, 0.6) inset;
   color: #FFFFFF;
 }
+
 .wpuf-coupon-info-wrap a.wpuf-apply-coupon {
   text-decoration: none;
   font-size: 11px;
@@ -692,10 +821,12 @@ ul.wpuf-form:not(.form-label-left) .wpuf-submit .wpuf-label {
   -moz-border-radius: 3px;
   border-radius: 3px;
 }
+
 .wpuf-coupon-info-wrap .wpuf-copon-cancel {
   text-decoration: none;
   font-size: 11px;
 }
+
 .entry-content ul.wpuf_packs,
 ul.wpuf_packs {
   overflow: hidden;
@@ -704,8 +835,9 @@ ul.wpuf_packs {
   width: 100%;
   padding-left: 0;
 }
-.entry-content ul.wpuf_packs > li,
-ul.wpuf_packs > li {
+
+.entry-content ul.wpuf_packs>li,
+ul.wpuf_packs>li {
   background: #fff;
   display: inline-block;
   vertical-align: top;
@@ -717,24 +849,30 @@ ul.wpuf_packs > li {
   width: 200px;
   box-shadow: 0 2px 6px rgba(100, 100, 100, 0.3);
 }
+
 @media (max-width: 991px) {
+
   .entry-content ul.wpuf_packs,
   ul.wpuf_packs {
     text-align: center;
     padding-left: 25px;
   }
 }
+
 @media (max-width: 500px) {
+
   .entry-content ul.wpuf_packs,
   ul.wpuf_packs {
     padding-left: 0;
   }
-  .entry-content ul.wpuf_packs > li,
-  ul.wpuf_packs > li {
+
+  .entry-content ul.wpuf_packs>li,
+  ul.wpuf_packs>li {
     width: 100%;
     margin-left: 0;
   }
 }
+
 .entry-content ul.wpuf_packs h3,
 ul.wpuf_packs h3 {
   background: #52B5D5;
@@ -746,10 +884,12 @@ ul.wpuf_packs h3 {
   text-align: center;
   border-bottom: 1px solid #3dacd0;
 }
+
 .entry-content ul.wpuf_packs .wpuf-pricing-wrap,
 ul.wpuf_packs .wpuf-pricing-wrap {
   background: #64C3DE;
 }
+
 .entry-content ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount,
 ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount {
   position: relative;
@@ -758,6 +898,7 @@ ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount {
   border-bottom: 1px solid #4fbbda;
   padding: 10px 0;
 }
+
 .entry-content ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount .wpuf-sub-symbol,
 ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount .wpuf-sub-symbol {
   font-size: 19px;
@@ -765,17 +906,20 @@ ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount .wpuf-sub-symbol {
   top: 25px;
   line-height: 10px;
 }
+
 .entry-content ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount .wpuf-sub-cost,
 ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount .wpuf-sub-cost {
   font-size: 40px;
   margin-left: 10px;
   line-height: 50px;
 }
+
 .entry-content ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount .wpuf-pack-cycle,
 ul.wpuf_packs .wpuf-pricing-wrap .wpuf-sub-amount .wpuf-pack-cycle {
   font-size: 13px;
   padding-bottom: 5px;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-body,
 ul.wpuf_packs .wpuf-sub-body {
   margin: 0;
@@ -784,6 +928,7 @@ ul.wpuf_packs .wpuf-sub-body {
   font-size: 11px;
   color: #999;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-button,
 ul.wpuf_packs .wpuf-sub-button {
   text-align: center;
@@ -791,6 +936,7 @@ ul.wpuf_packs .wpuf-sub-button {
   margin-top: 20px;
   overflow: hidden;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-button a,
 ul.wpuf_packs .wpuf-sub-button a {
   background: #64C3DE;
@@ -802,10 +948,12 @@ ul.wpuf_packs .wpuf-sub-button a {
   border-radius: 3px;
   display: inline-block;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-button a:hover,
 ul.wpuf_packs .wpuf-sub-button a:hover {
   background: #3ab3d5;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-button a:hover,
 ul.wpuf_packs .wpuf-sub-button a:hover {
   background: none repeat scroll 0 0 #1E8CBE;
@@ -813,10 +961,12 @@ ul.wpuf_packs .wpuf-sub-button a:hover {
   box-shadow: 0 1px 0 rgba(120, 200, 230, 0.6) inset;
   color: #FFFFFF;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-desciption,
 ul.wpuf_packs .wpuf-sub-desciption {
   margin-top: 15px;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-desciption ul,
 ul.wpuf_packs .wpuf-sub-desciption ul,
 .entry-content ul.wpuf_packs .wpuf-sub-desciption li,
@@ -825,25 +975,30 @@ ul.wpuf_packs .wpuf-sub-desciption li {
   padding: 0;
   list-style: none;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-desciption li,
 ul.wpuf_packs .wpuf-sub-desciption li {
   text-align: center;
   border-top: 1px solid #eee;
   padding: 7px 0;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-desciption li:last-child,
 ul.wpuf_packs .wpuf-sub-desciption li:last-child {
   border-bottom: 1px solid #eee;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-desciption li:first-child,
 ul.wpuf_packs .wpuf-sub-desciption li:first-child {
   border-top: none;
 }
+
 .entry-content ul.wpuf_packs .wpuf-sub-desciption p,
 ul.wpuf_packs .wpuf-sub-desciption p {
   padding: 0 10px;
   margin-bottom: 15px;
 }
+
 .entry-content ul.wpuf_packs .button,
 ul.wpuf_packs .button {
   background: none repeat scroll 0 0 #2EA2CC;
@@ -854,6 +1009,7 @@ ul.wpuf_packs .button {
   padding: 0 12px 2px;
   color: #fff;
 }
+
 .entry-content ul.wpuf_packs .cost,
 ul.wpuf_packs .cost {
   background: red;
@@ -865,38 +1021,48 @@ ul.wpuf_packs .cost {
   right: 0;
   top: 0;
 }
+
 /* css for timepicker */
 .ui-timepicker-div .ui-widget-header {
   margin-bottom: 8px;
 }
+
 .ui-timepicker-div dl {
   text-align: left;
 }
+
 .ui-timepicker-div dl dt {
   height: 25px;
   margin-bottom: -25px;
 }
+
 .ui-timepicker-div dl dd {
   margin: 0 10px 10px 65px;
 }
+
 .ui-timepicker-div td {
   font-size: 90%;
 }
+
 .ui-tpicker-grid-label {
   background: none;
   border: none;
   margin: 0;
   padding: 0;
 }
+
 .ui-timepicker-rtl {
   direction: rtl;
 }
+
 .ui-timepicker-rtl dl {
   text-align: right;
 }
+
 .ui-timepicker-rtl dl dd {
   margin: 0 65px 10px 10px;
 }
+
 .pass-strength-result {
   border-style: solid;
   border-width: 1px;
@@ -909,31 +1075,38 @@ ul.wpuf_packs .cost {
   background-color: #eee;
   border-color: #ddd !important;
 }
+
 .pass-strength-result.bad {
   background-color: #ffb78c;
   border-color: #ff853c !important;
 }
+
 .pass-strength-result.good {
   background-color: #ffec8b;
   border-color: #fc0 !important;
 }
+
 .pass-strength-result.short {
   background-color: #ffa0a0;
   border-color: #f04040 !important;
 }
+
 .pass-strength-result.strong {
   background-color: #c3ff88;
   border-color: #8dff1c !important;
 }
+
 .password[type="text"] {
   display: none;
 }
+
 table.wpuf-table {
   border: 1px solid #E7E7E7;
   margin: 0 0px 10px 0;
   text-align: left;
   width: 100%;
 }
+
 table.wpuf-table thead th,
 table.wpuf-table th {
   color: #888888;
@@ -942,26 +1115,32 @@ table.wpuf-table th {
   line-height: 18px;
   padding: 9px 24px;
 }
+
 table.wpuf-table td {
   border-top: 1px solid #E7E7E7;
   padding: 6px 24px;
 }
+
 @media (max-width: 549px) {
   #wpuf-payment-gateway {
     margin-left: -15px;
   }
 }
+
 #wpuf-payment-gateway ul.wpuf-payment-gateways {
   list-style: none;
   margin: 10px 0;
 }
+
 #wpuf-payment-gateway ul.wpuf-payment-gateways li {
   margin: 0;
 }
+
 #wpuf-payment-gateway ul.wpuf-payment-gateways li .wpuf-payment-instruction {
   padding: 8px 10px;
   margin: 0 10px;
 }
+
 #wpuf-payment-gateway ul.wpuf-payment-gateways li .wpuf-instruction {
   padding: 8px 10px;
   margin-bottom: 10px;
@@ -971,11 +1150,13 @@ table.wpuf-table td {
   -moz-border-radius: 2px;
   border-radius: 2px;
 }
+
 .wpuf-pagination div.pagination {
   text-align: center;
   padding: 7px;
   margin: 3px;
 }
+
 .wpuf-pagination .page-numbers {
   padding: 2px 8px;
   margin: 2px;
@@ -986,6 +1167,7 @@ table.wpuf-table td {
   border-radius: 5px;
   -moz-border-radius: 5px;
 }
+
 .wpuf-pagination .page-numbers:hover,
 .wpuf-pagination .page-numbers:active {
   border: 1px solid #4A5154;
@@ -994,6 +1176,7 @@ table.wpuf-table td {
   border-radius: 5px;
   -moz-border-radius: 5px;
 }
+
 .wpuf-pagination .page-numbers.current {
   padding: 2px 8px;
   margin: 2px;
@@ -1004,21 +1187,25 @@ table.wpuf-table td {
   border-radius: 5px;
   -moz-border-radius: 5px;
 }
+
 /** author info **/
 .wpuf-author {
   margin: 20px 0;
 }
+
 .wpuf-author:after {
   clear: both;
   content: "";
   display: table;
 }
+
 .wpuf-author h3 {
   margin: 0 !important;
   background: #CFCFCF;
   text-align: left;
   padding: 3px 10px;
 }
+
 .wpuf-author .wpuf-author-inside {
   background: none repeat scroll 0 0 #F0F0F0;
   border-bottom: 2px solid #DDDDDD;
@@ -1027,27 +1214,33 @@ table.wpuf-table td {
   padding-top: 15px;
   margin-bottom: 15px;
 }
+
 .wpuf-author .wpuf-author-inside:after {
   clear: both;
   content: "";
   display: table;
 }
+
 .wpuf-author .wpuf-author-inside .wpuf-user-image {
   float: left;
   padding-right: 15px;
 }
+
 .wpuf-author .wpuf-author-inside p {
   margin-bottom: 10px !important;
 }
+
 .wpuf-author .wpuf-author-inside p.wpuf-author-info {
   padding-top: 8px;
   word-wrap: break-word;
 }
+
 .wpuf-author .wpuf-author-inside p.wpuf-user-name a {
   color: #335160;
   font-size: 1.2em;
   font-weight: bold;
 }
+
 /** jQuery Suggest **/
 .ac_results {
   padding: 0;
@@ -1058,17 +1251,21 @@ table.wpuf-table td {
   display: none;
   border: 1px solid #ccc;
 }
+
 .ac_results li {
   padding: 2px 5px;
   white-space: nowrap;
   text-align: left;
 }
+
 .ac_over {
   cursor: pointer;
 }
+
 .ac_match {
   text-decoration: underline;
 }
+
 /*------------------------------------
  * Multistep form
  *-----------------------------------*/
@@ -1078,31 +1275,39 @@ fieldset.wpuf-multistep-fieldset {
   border: none;
   display: none;
 }
+
 fieldset.wpuf-multistep-fieldset.field-active {
   display: block;
 }
+
 fieldset.wpuf-multistep-fieldset .wpuf-multistep-prev-btn,
 fieldset.wpuf-multistep-fieldset .wpuf-multistep-next-btn {
   position: absolute;
   bottom: 5px;
 }
+
 fieldset.wpuf-multistep-fieldset .wpuf-multistep-prev-btn {
   left: 10px;
 }
+
 fieldset.wpuf-multistep-fieldset .wpuf-multistep-next-btn {
   right: 10px;
 }
+
 .wpuf-multistep-progressbar {
   overflow: hidden;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard {
   margin: 20px 0 40px 0;
   padding: 0;
   list-style: none;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard * {
   box-sizing: border-box;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li {
   background-color: #E4E4E4;
   border-radius: 5px;
@@ -1114,6 +1319,7 @@ fieldset.wpuf-multistep-fieldset .wpuf-multistep-next-btn {
   position: relative;
   text-align: center;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li::before,
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li::after {
   border: solid transparent;
@@ -1125,12 +1331,14 @@ fieldset.wpuf-multistep-fieldset .wpuf-multistep-next-btn {
   border-left-color: #fff;
   border-radius: 10px;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li::before {
   border-width: 26px;
   margin-top: -14px;
   right: -52px;
   z-index: 98;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li::after {
   border-left-color: #E4E4E4;
   border-width: 25px;
@@ -1138,25 +1346,31 @@ fieldset.wpuf-multistep-fieldset .wpuf-multistep-next-btn {
   right: -44px;
   z-index: 99;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li.active-step {
   background-color: #00a0d2;
   color: #fff;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li.active-step::after {
   border-left-color: #00a0d2;
 }
+
 .wpuf-form .wpuf-multistep-progressbar ul.wpuf-step-wizard li:last-child::after {
   border-left-color: transparent;
 }
+
 .wpuf-form .wpuf-multistep-progressbar .ui-widget-header {
   background: #00a0d2;
 }
+
 .wpuf-form .wpuf-multistep-progressbar.ui-progressbar {
   margin-bottom: 30px;
   height: 25px;
   border: 1px solid #eee;
   position: relative;
 }
+
 .wpuf-form .wpuf-multistep-progressbar.ui-progressbar .wpuf-progress-percentage {
   position: absolute;
   left: 50%;
@@ -1165,6 +1379,7 @@ fieldset.wpuf-multistep-fieldset .wpuf-multistep-next-btn {
   text-shadow: 1px 1px 0 #fff;
   top: 20%;
 }
+
 input.wpuf-btn {
   text-decoration: none !important;
   font-size: 15px !important;
@@ -1179,77 +1394,95 @@ input.wpuf-btn {
   border-radius: 3px !important;
   border: none !important;
 }
+
 /*rtl*/
 body.rtl ul.wpuf-form li .wpuf-label {
   float: right;
 }
+
 @media (max-width: 480px) {
+
   ul.wpuf-form li .wpuf-label,
   ul.wpuf-form li .wpuf-fields {
     float: none;
     width: 100%;
   }
+
   ul.wpuf-form li.field-size-large .wpuf-fields {
     float: none;
     width: 100%;
   }
+
   ul.wpuf-form li.field-size-medium .wpuf-fields {
     float: none;
     width: 65%;
   }
+
   ul.wpuf-form li.field-size-small .wpuf-fields {
     float: none;
     width: 30%;
   }
 }
+
 .wpuf-form .required {
   color: red;
   font-weight: 700;
   border: 0;
 }
+
 .wpuf-dashboard-container:after {
   clear: both;
   content: "";
   display: table;
 }
+
 .wpuf-dashboard-container .wpuf-dashboard-navigation {
   width: 30%;
   float: left;
 }
+
 .wpuf-dashboard-container .wpuf-dashboard-navigation a {
   text-decoration: none;
   box-shadow: none;
 }
+
 .wpuf-dashboard-container .wpuf-dashboard-navigation ul {
   list-style: none;
   margin: 0;
   padding: 0;
 }
+
 .wpuf-dashboard-container .wpuf-dashboard-navigation ul li {
   padding-bottom: 2px;
 }
+
 @media (max-width: 991px) {
   .wpuf-dashboard-container .wpuf-dashboard-navigation {
     width: 100%;
     margin-bottom: 30px;
   }
+
   .wpuf-dashboard-container .wpuf-dashboard-navigation ul {
     margin: 0 -7px;
   }
+
   .wpuf-dashboard-container .wpuf-dashboard-navigation ul li {
     margin: 0 7px;
     display: inline-block;
   }
 }
+
 .wpuf-dashboard-container .wpuf-dashboard-content {
   width: 68%;
   float: right;
 }
+
 @media (max-width: 991px) {
   .wpuf-dashboard-container .wpuf-dashboard-content {
     width: 100%;
   }
 }
+
 .wpuf-dashboard-container .wpuf-dashboard-content .wpuf-fields select:not([type="submit"]),
 .wpuf-dashboard-container .wpuf-dashboard-content .wpuf-fields textarea:not([type="submit"]),
 .wpuf-dashboard-container .wpuf-dashboard-content .wpuf-fields input:not([type="submit"]),
@@ -1270,81 +1503,100 @@ body.rtl ul.wpuf-form li .wpuf-label {
 .wpuf-dashboard-container .wpuf-dashboard-content .wpuf-fields input:not([type="reset"]) {
   width: 100%;
 }
+
 .wpuf-dashboard-container .items-table-container,
 .wpuf-dashboard-container .wpuf-dashboard-content.invoices {
   max-width: 100%;
   overflow-y: auto;
 }
+
 .wpuf-dashboard-container table.items-table {
   min-width: 600px;
   border: 0;
 }
+
 .wpuf-dashboard-container table.items-table a {
   text-decoration: none;
   box-shadow: none;
 }
+
 .wpuf-dashboard-container table.items-table th,
 .wpuf-dashboard-container table.items-table td {
   border: 0;
   padding: 10px;
 }
+
 .wpuf-dashboard-container table.items-table tr {
   text-align: left;
   outline: 1px solid #f1f1f1;
 }
+
 .wpuf-dashboard-container table.items-table .items-list-header {
   background-color: #f1f1f1;
 }
+
 .wpuf-dashboard-container .wpuf-update-profile-form ul.wpuf-form {
   margin: 0 -15px !important;
   width: inherit;
 }
+
 .wpuf-dashboard-container .wpuf-update-profile-form ul.wpuf-form .form-row-first {
   float: left;
   width: 50%;
   padding: 0 15px;
   overflow: visible;
 }
+
 .wpuf-dashboard-container .wpuf-update-profile-form ul.wpuf-form .form-row-last {
   float: right;
   width: 50%;
   padding: 0 15px;
   overflow: visible;
 }
+
 @media (max-width: 767px) {
+
   .wpuf-dashboard-container .wpuf-update-profile-form ul.wpuf-form .form-row-first,
   .wpuf-dashboard-container .wpuf-update-profile-form ul.wpuf-form .form-row-last {
     float: none;
     width: 100%;
   }
 }
+
 .wpuf-wcmp-integration-content .wpuf-dashboard-container .page-head {
   opacity: 0;
   margin-bottom: 40px;
 }
+
 .wpuf-wcmp-integration-content .wpuf-dashboard-container table.items-table {
   width: 100%;
   margin-bottom: 40px !important;
 }
+
 .wpuf-toc-container .wpuf-fields {
   position: relative;
 }
+
 .wpuf-toc-container .wpuf-fields .wpuf-toc-checkbox {
   position: absolute;
   top: 0;
   left: 0;
 }
+
 .wpuf-toc-container .wpuf-fields.has-toc-checkbox .wpuf-toc-description {
   margin-left: 25px;
 }
+
 .wpuf-field-google-map {
   height: 300px;
   width: 100%;
 }
+
 .wpuf-form-google-map {
   height: 300px;
   width: 100%;
 }
+
 input[type="text"].wpuf-google-map-search {
   margin-top: 10px !important;
   border: 1px solid transparent !important;
@@ -1363,24 +1615,31 @@ input[type="text"].wpuf-google-map-search {
   padding: 0 11px 0 13px !important;
   display: none;
 }
+
 .gm-style input[type="text"].wpuf-google-map-search {
   display: block;
 }
+
 .wpuf-form-google-map-container input[type="text"].wpuf-google-map-search {
   width: 230px !important;
 }
+
 .wpuf-form-google-map-container.hide-search-box .gm-style input[type="text"].wpuf-google-map-search {
   display: none;
 }
+
 .dokan-dashboard-content.dokan-wpuf-dashboard h2.page-head {
   display: none;
 }
+
 .dokan-dashboard-content.dokan-wpuf-dashboard .wpuf-author {
   display: none;
 }
+
 .dokan-dashboard-content.dokan-wpuf-dashboard .wpuf-form-add .wpuf-form li.wpuf-el {
   margin-bottom: 15px;
 }
+
 table#wpuf-address-country-state input {
   width: 100%;
   padding: 0 10px;
@@ -1391,6 +1650,7 @@ table#wpuf-address-country-state input {
   height: 36px;
   box-shadow: none;
 }
+
 table#wpuf-address-country-state select {
   width: 100%;
   padding: 0 10px;
@@ -1401,12 +1661,15 @@ table#wpuf-address-country-state select {
   height: 36px;
   box-shadow: none;
 }
+
 table#wpuf-address-country-state input.wpuf-btn {
   width: inherit;
 }
+
 table#wpuf-address-country-state td {
   border: none;
 }
+
 .wpuf-image-wrap {
   display: inline-block;
   position: relative;
@@ -1414,6 +1677,7 @@ table#wpuf-address-country-state td {
   transition: .3s;
   margin: 4px;
 }
+
 .wpuf-image-wrap .attachment-name img {
   width: 100%;
   max-height: 150px;
@@ -1422,9 +1686,11 @@ table#wpuf-address-country-state td {
   box-shadow: none;
   -webkit-box-shadow: none;
 }
+
 li.wpuf-image-wrap.thumbnail {
   position: relative;
 }
+
 li.wpuf-image-wrap.thumbnail .caption {
   position: absolute;
   left: 50%;
@@ -1439,32 +1705,39 @@ li.wpuf-image-wrap.thumbnail .caption {
   border-radius: 3px;
   line-height: 0;
 }
+
 li.wpuf-image-wrap.thumbnail:hover .caption {
   display: block;
 }
+
 @media (min-width: 550px) {
   .wpuf-pay-row {
     width: 100%;
     display: table;
     table-layout: auto;
   }
+
   .wpuf-pay-col {
     width: 50%;
     display: table-cell;
   }
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list {
   overflow: auto;
 }
+
 ul.wpuf-form li .wpuf-fields ul.wpuf-attachment-list li.highlight {
   margin-bottom: 0;
   height: 150px;
   padding-top: 0;
   padding-bottom: 0;
 }
+
 ul.wpuf-form .ui-state-default.wpuf-image-wrap:hover {
   cursor: move;
 }
+
 ul.wpuf-form .ui-state-default.wpuf-image-wrap .caption a,
 ul.wpuf-form .ui-state-default.wpuf-image-wrap .caption span {
   display: inline-block;
@@ -1474,22 +1747,26 @@ ul.wpuf-form .ui-state-default.wpuf-image-wrap .caption span {
   color: transparent;
   vertical-align: top;
 }
+
 ul.wpuf-form .ui-state-default .wpuf-image-wrap .caption a img {
   -webkit-box-shadow: none;
   box-shadow: none;
 }
+
 ul.wpuf-form .ui-state-default.wpuf-image-wrap .caption a:hover,
 ul.wpuf-form .ui-state-default.wpuf-image-wrap .caption span:hover {
   background: #0073aa;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
+
 .weforms-quiz-feedback {
   position: relative;
   padding-top: 50px;
   padding-bottom: 50px;
   margin-top: 50px;
 }
+
 .weforms-quiz-feedback .weforms-quiz-points {
   position: absolute;
   top: 0;
@@ -1497,15 +1774,18 @@ ul.wpuf-form .ui-state-default.wpuf-image-wrap .caption span:hover {
   width: 200px;
   text-align: right;
 }
+
 .weforms-quiz-feedback .weforms-field-points {
   float: right;
 }
+
 .weforms-quiz-feedback .weforms-quiz-points .score {
   background: #673ab7;
   color: #fff;
   padding: 12px 20px;
   border-radius: 5px;
 }
+
 .weforms-quiz-feedback .right-answer-block,
 .weforms-quiz-feedback .weforms-answer-feedback {
   margin-top: 2px;
@@ -1514,30 +1794,37 @@ ul.wpuf-form .ui-state-default.wpuf-image-wrap .caption span:hover {
   color: rgba(0, 0, 0, 0.87);
   font-weight: 700;
 }
+
 .weforms-quiz-feedback .right-answer-block p,
 .weforms-quiz-feedback .weforms-answer-feedback p {
   margin-bottom: 10px;
 }
+
 .weforms-quiz-feedback .weforms-answer-feedback .feedback {
   font-weight: 400;
 }
+
 .weforms-quiz-feedback .right-answer,
 .weforms-quiz-feedback .wrong-answer {
   margin-bottom: 20px;
 }
+
 .weforms-quiz-feedback .right-answer .wpuf-fields label.checked {
   background: #dff0d8;
   color: #3c763d;
   padding: 6px 0;
 }
+
 .weforms-quiz-feedback .wrong-answer .wpuf-fields label.checked {
   background: #FFE4E4;
   color: red;
   padding: 6px 0;
 }
+
 ul.wpuf-form .wpuf-el {
   position: relative;
 }
+
 ul.wpuf-form .weforms-frontend-field-points {
   position: absolute;
   top: 0;
@@ -1549,6 +1836,7 @@ ul.wpuf-form .weforms-frontend-field-points {
   font-weight: 700;
   text-align: right;
 }
+
 .dokan-dashboard .dokan-dashboard-content ul li.wpuf-el,
 .dokan-dashboard .dokan-dashboard-content ul li.wpuf-submit {
   margin-left: 0;
@@ -1556,67 +1844,83 @@ ul.wpuf-form .weforms-frontend-field-points {
   padding: 10px;
   padding-left: 0;
 }
+
 /* Front End Posts List Tools */
 .wpuf-posts-options {
   padding: 0 10px;
   border-right: 1px solid #ccc;
 }
+
 .wpuf-posts-options:first-child {
   padding-left: 0;
 }
+
 .wpuf-posts-options:last-child {
   padding-right: 0;
   border-right: 0;
 }
+
 /* CSS for custom columns */
 .wpuf-col-half,
 .wpuf-col-half-last {
   width: 50%;
   float: left;
 }
+
 .wpuf-col-one-third,
 .wpuf-col-one-third-last {
   width: 33%;
   float: left;
 }
-.wpuf-col-half-last + li,
-.wpuf-col-one-third-last + li {
+
+.wpuf-col-half-last+li,
+.wpuf-col-one-third-last+li {
   clear: left;
 }
+
 ul.wpuf-form .wpuf-field-columns {
   padding: 0;
   border: 0;
   overflow: hidden;
 }
+
 ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .wpuf-column-inner-fields {
   width: 100%;
   float: left;
 }
+
 ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .column-1 .ui-resizable-handle {
   display: none !important;
 }
+
 ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .column-2.wpuf-column-inner-fields,
 ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .column-3.wpuf-column-inner-fields {
   display: none;
 }
+
 ul.wpuf-form .wpuf-field-columns.has-columns-2 .wpuf-column .wpuf-column-inner-fields {
   width: 50%;
   float: left;
 }
+
 ul.wpuf-form .wpuf-field-columns.has-columns-2 .wpuf-column .column-2 .ui-resizable-handle {
   display: none !important;
 }
+
 ul.wpuf-form .wpuf-field-columns.has-columns-2 .wpuf-column .column-3.wpuf-column-inner-fields {
   display: none;
 }
+
 ul.wpuf-form .wpuf-field-columns.has-columns-3 .wpuf-column .wpuf-column-inner-fields {
   width: 33.33%;
   float: left;
 }
+
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns {
   margin-left: 0;
   margin-right: 0;
 }
+
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column {
   padding: 0;
   border: 0;
@@ -1624,19 +1928,23 @@ ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column {
   width: 100%;
   overflow: hidden;
 }
+
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields {
   padding: 0 5px 0 0;
   position: relative;
 }
+
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields {
   border: 0;
   margin: 0;
   padding: 0;
   list-style: none;
 }
+
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields li {
   padding: 0;
 }
+
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields li input[type="text"],
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields li input[type="email"],
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields li input[type="url"],


### PR DESCRIPTION
Fixed contrast in form error messages when text is white or light colored for dark backgrounds. Fixes #177 

### Testing

1. Create a page with a dark background ( Used crio and P&PB )
2. Create a form with at least one required fields
3. Submit the form without filling out the required field.
4. Text should change from white ( Light color ) to black for the error message.