### PR TITLE
adds nonce and role verification to entry exports.

### DIFF
--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -170,9 +170,19 @@ class WeForms_Admin {
      * @return void
      */
     public function export_form_entries() {
+        if ( ! current_user_can( 'administrator' ) ) {
+            $error = new WP_Error( 'rest_weforms_invalid_permission', __( 'You do not have permission to export entries', 'weforms' ), [ 'status' => 404 ] );
+            wp_die( esc_html__( $error->get_error_message(), 'weforms' ) );
+        }
+
+        if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'weforms-export-entries' ) ) {
+            $error = new WP_Error( 'rest_weforms_invalid_nonce', __( 'Invalid nonce', 'weforms' ), [ 'status' => 404 ] );
+            wp_die( esc_html__( $error->get_error_message(), 'weforms' ) );
+        }
+
         $form_id = isset( $_REQUEST['selected_forms'] ) ? absint( $_REQUEST['selected_forms'] ) : 0;
 
-        if ( !$form_id ) {
+        if ( ! $form_id ) {
             return;
         }
 

--- a/includes/admin/class-admin.php
+++ b/includes/admin/class-admin.php
@@ -171,13 +171,11 @@ class WeForms_Admin {
      */
     public function export_form_entries() {
         if ( ! current_user_can( 'administrator' ) ) {
-            $error = new WP_Error( 'rest_weforms_invalid_permission', __( 'You do not have permission to export entries', 'weforms' ), [ 'status' => 404 ] );
-            wp_die( esc_html__( $error->get_error_message(), 'weforms' ) );
+            wp_die( esc_html__( 'You do not have permission to export entries', 'weforms' ) );
         }
 
         if ( ! wp_verify_nonce( $_REQUEST['_wpnonce'], 'weforms-export-entries' ) ) {
-            $error = new WP_Error( 'rest_weforms_invalid_nonce', __( 'Invalid nonce', 'weforms' ), [ 'status' => 404 ] );
-            wp_die( esc_html__( $error->get_error_message(), 'weforms' ) );
+            wp_die( esc_html__( 'Invalid nonce', 'weforms' ) );
         }
 
         $form_id = isset( $_REQUEST['selected_forms'] ) ? absint( $_REQUEST['selected_forms'] ) : 0;


### PR DESCRIPTION
Fixes weforms pro issue-139

### Testing
Nonce Testing
1.  Click on All forms
2.  Click on  View Entries under a form
3.  Right click and copy link address for Export Entries
4.  Paste that link in a new tab and remove nonce at the end i.e. `&_wpnonce=02a2466c09`
5.  Should get an invalid nonce message.
6. 
Role Testing
1. Create a new user with a role less than admin. 
2. Click on All forms
3.  Click on  View Entries under a form
4.  Right click and copy link address for Export Entries
5.  Paste that link in a new window where the new user is logged in.
7.  Should get an invalid permission message.