### PR TITLE
fixes broken access control in form submission

### DIFF
--- a/assets/wpuf/js/frontend-form.js
+++ b/assets/wpuf/js/frontend-form.js
@@ -450,7 +450,7 @@
                                 type: 'warning',
                                 showCancelButton: false,
                                 confirmButtonColor: '#d54e21',
-                                confirmButtonText: 'Ok',
+                                confirmButtonText: 'OK',
                                 cancelButtonClass: 'btn btn-danger',
                             });
 

--- a/assets/wpuf/js/frontend-form.js
+++ b/assets/wpuf/js/frontend-form.js
@@ -450,7 +450,7 @@
                                 type: 'warning',
                                 showCancelButton: false,
                                 confirmButtonColor: '#d54e21',
-                                confirmButtonText: 'OK',
+                                confirmButtonText: 'Ok',
                                 cancelButtonClass: 'btn btn-danger',
                             });
 

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -1253,16 +1253,4 @@ class WeForms_Ajax {
 
         wp_send_json_success();
     }
-
-    /**
-     * Show form error
-     *
-     * @param string $message
-     * @param string $type
-     *
-     * @return string
-     */
-    public function show_error( $message, $type = 'info' ) {
-        return sprintf( '<div class="wpuf-%s">%s</div>', $type, $message );
-    }
 }

--- a/includes/class-ajax.php
+++ b/includes/class-ajax.php
@@ -711,8 +711,20 @@ class WeForms_Ajax {
         check_ajax_referer( 'wpuf_form_add' );
         $form_id       = isset( $_POST['form_id'] ) ? intval( $_POST['form_id'] ) : 0;
         $page_id       = isset( $_POST['page_id'] ) ? intval( $_POST['page_id'] ) : 0;
-
         $form          = weforms()->form->get( $form_id );
+
+        /**
+         * Check if form submission is open. This resolves broken access control with unauthenticated users.
+         * Access is now checked on frontend form rendering and submission.
+         */
+        $form_submission_status = $form->is_submission_open();
+        if ( is_wp_error( $form_submission_status ) ) {
+            wp_send_json( [
+                'success'     => false,
+                'error'       => __( 'Login Required for submission.', 'weforms' ),
+            ] );
+        }
+
         $form_settings = $form->get_settings();
         $form_fields   = $form->get_fields();
         $entry_fields  = $form->prepare_entries();
@@ -1240,5 +1252,17 @@ class WeForms_Ajax {
         @unlink( $file );
 
         wp_send_json_success();
+    }
+
+    /**
+     * Show form error
+     *
+     * @param string $message
+     * @param string $type
+     *
+     * @return string
+     */
+    public function show_error( $message, $type = 'info' ) {
+        return sprintf( '<div class="wpuf-%s">%s</div>', $type, $message );
     }
 }


### PR DESCRIPTION
fixes pro issue 141

### Testing
1.) Create 2 forms.
2.) One form will be a login restricted form. Go to the form Settings > Submission Restriction.
3.) Turn on Require Login.
4.) You should now have two forms. One is login restricted, and the other is not.
5.) Create separate posts for both forms. You can use the shortcode. Publish them both Publicly.
6.) Open an unauthenticated session.
7.) Go to the post with no login required.
8.) Fill up the form then intercept the request when you click submit.
9.) Send this request to repeater.
10.) In Burp Repeater change the value of the "form_id" to the form id of the login required form. You can see the form id in its shortcode.
11.) Submit this request.