### PR TITLE
Patched XSS vulnerablity

### DIFF
--- a/assets/js-templates/spa-components.php
+++ b/assets/js-templates/spa-components.php
@@ -426,6 +426,7 @@
                                             <div v-else-if="field.type === 'country_list_field'">{{ getCountryName( field.value ) }}</div>
                                             <div v-else-if="field.type === 'address_field'" v-html="getAddressFieldValue( field.value)"></div>
                                             <div v-else-if="field.type === 'textarea_field'" v-html="field.value"></div>
+                                            <div v-else-if="field.type === 'image_upload' || field.type === 'file_upload' || field.type === 'signature_field' || field.type === 'checkbox_grid' || field.type === 'multiple_choice_grid'" v-html="field.value"></div>
                                             <div v-else>{{ field.value }}</div>
                                         </td>
                                     </tr>

--- a/assets/js-templates/spa-components.php
+++ b/assets/js-templates/spa-components.php
@@ -426,7 +426,7 @@
                                             <div v-else-if="field.type === 'country_list_field'">{{ getCountryName( field.value ) }}</div>
                                             <div v-else-if="field.type === 'address_field'" v-html="getAddressFieldValue( field.value)"></div>
                                             <div v-else-if="field.type === 'textarea_field'" v-html="field.value"></div>
-                                            <div v-else-if="field.type === 'image_upload' || field.type === 'file_upload' || field.type === 'signature_field' || field.type === 'checkbox_grid' || field.type === 'multiple_choice_grid'" v-html="field.value"></div>
+                                            <div v-else-if="field.type === 'image_upload' || field.type === 'file_upload' || field.type === 'signature_field' || field.type === 'checkbox_grid' || field.type === 'multiple_choice_grid' || field.type === 'multiple_product'" v-html="field.value"></div>
                                             <div v-else>{{ field.value }}</div>
                                         </td>
                                     </tr>

--- a/assets/js-templates/spa-components.php
+++ b/assets/js-templates/spa-components.php
@@ -77,7 +77,7 @@
                         <th scope="row" class="check-column">
                             <input type="checkbox" name="post[]" v-model="checkedItems" :value="entry.id">
                         </th>
-                        <td v-for="(header, index) in columns"><span v-html="entry.fields[index]"></span></td>
+                        <td v-for="(header, index) in columns"><span>{{ entry.fields[index] }}</span></td>
                         <th class="col-entry-details">
                             <template v-if="status == 'trash'">
                                 <a href="#" @click.prevent="restore(entry.id)"><?php esc_html_e( 'Restore', 'weforms' ); ?></a>
@@ -96,7 +96,7 @@
                     <th scope="row" class="check-column">
                         <input type="checkbox" name="post[]" v-model="checkedItems" :value="entry.id">
                     </th>
-                    <td v-for="(header, index) in columns"><span v-html="entry.fields[index]"></span></td>
+                    <td v-for="(header, index) in columns"><span>{{ entry.fields[index] }}</span></td>
                     <th class="col-entry-details">
                         <template v-if="status == 'trash'">
                             <a href="#" @click.prevent="restore(entry.id)"><?php esc_html_e( 'Restore', 'weforms' ); ?></a>
@@ -425,7 +425,8 @@
                                             </div>
                                             <div v-else-if="field.type === 'country_list_field'">{{ getCountryName( field.value ) }}</div>
                                             <div v-else-if="field.type === 'address_field'" v-html="getAddressFieldValue( field.value)"></div>
-                                            <div v-else v-html="field.value"></div>
+                                            <div v-else-if="field.type === 'textarea_field'" v-html="field.value"></div>
+                                            <div v-else>{{ field.value }}</div>
                                         </td>
                                     </tr>
                                 </template>

--- a/assets/spa/components/component-table/template.php
+++ b/assets/spa/components/component-table/template.php
@@ -81,7 +81,7 @@
                         <th class="col-entry-id">
                             <router-link :to="{ name: 'formEntriesSingle', params: { entryid: entry.id }}">#{{ entry.id }}</router-link>
                         </th>
-                        <td v-for="(header, index) in columns"><span v-html="entry.fields[index]"></span></td>
+                        <td v-for="(header, index) in columns"><span>{{ entry.fields[index] }}</span></td>
                         <th class="col-entry-details">
                             <template v-if="status == 'trash'">
                                 <a href="#" @click.prevent="restore(entry.id)"><?php _e( 'Restore', 'weforms' ); ?></a>
@@ -103,7 +103,7 @@
                     <th class="col-entry-id">
                         <router-link :to="{ name: 'formEntriesSingle', params: { entryid: entry.id }}">#{{ entry.id }}</router-link>
                     </th>
-                    <td v-for="(header, index) in columns"><span v-html="entry.fields[index]"></span></td>
+                    <td v-for="(header, index) in columns"><span>{{ entry.fields[index] }}</span></td>
                     <th class="col-entry-details">
                         <template v-if="status == 'trash'">
                             <a href="#" @click.prevent="restore(entry.id)"><?php _e( 'Restore', 'weforms' ); ?></a>

--- a/assets/spa/components/form-entry-single/template.php
+++ b/assets/spa/components/form-entry-single/template.php
@@ -41,6 +41,7 @@
                                             <div v-else-if="field.type === 'country_list_field'">{{ getCountryName( field.value ) }}</div>
                                             <div v-else-if="field.type === 'address_field'" v-html="getAddressFieldValue( field.value)"></div>
                                             <div v-else-if="field.type === 'textarea_field'" v-html="field.value"></div>
+                                            <div v-else-if="field.type === 'image_upload' || field.type === 'file_upload' || field.type === 'signature_field' || field.type === 'checkbox_grid' || field.type === 'multiple_choice_grid'" v-html="field.value"></div>
                                             <div v-else>{{ field.value }}</div>
                                         </td>
                                     </tr>

--- a/assets/spa/components/form-entry-single/template.php
+++ b/assets/spa/components/form-entry-single/template.php
@@ -41,7 +41,7 @@
                                             <div v-else-if="field.type === 'country_list_field'">{{ getCountryName( field.value ) }}</div>
                                             <div v-else-if="field.type === 'address_field'" v-html="getAddressFieldValue( field.value)"></div>
                                             <div v-else-if="field.type === 'textarea_field'" v-html="field.value"></div>
-                                            <div v-else-if="field.type === 'image_upload' || field.type === 'file_upload' || field.type === 'signature_field' || field.type === 'checkbox_grid' || field.type === 'multiple_choice_grid'" v-html="field.value"></div>
+                                            <div v-else-if="field.type === 'image_upload' || field.type === 'file_upload' || field.type === 'signature_field' || field.type === 'checkbox_grid' || field.type === 'multiple_choice_grid' || field.type === 'multiple_product'" v-html="field.value"></div>
                                             <div v-else>{{ field.value }}</div>
                                         </td>
                                     </tr>

--- a/assets/spa/components/form-entry-single/template.php
+++ b/assets/spa/components/form-entry-single/template.php
@@ -40,7 +40,8 @@
                                             </div>
                                             <div v-else-if="field.type === 'country_list_field'">{{ getCountryName( field.value ) }}</div>
                                             <div v-else-if="field.type === 'address_field'" v-html="getAddressFieldValue( field.value)"></div>
-                                            <div v-else v-html="field.value"></div>
+                                            <div v-else-if="field.type === 'textarea_field'" v-html="field.value"></div>
+                                            <div v-else>{{ field.value }}</div>
                                         </td>
                                     </tr>
                                 </template>

--- a/includes/api/class-weforms-forms-controller.php
+++ b/includes/api/class-weforms-forms-controller.php
@@ -255,7 +255,7 @@ class Weforms_Forms_Controller extends Weforms_REST_Controller {
             $entry_fields = [];
 
             foreach ( $form_fields as $key => $field ) {
-                if ( $field['wpuf_cond']['condition_status'] == 'yes' ) {
+                if ( ! empty( $field['wpuf_cond'] ) && $field['wpuf_cond']['condition_status'] == 'yes' ) {
                     $logic          = [];
                     $cond_fields    = $field['wpuf_cond']['cond_field'];
                     $cond_operators = $field['wpuf_cond']['cond_operator'];

--- a/includes/class-form-entry.php
+++ b/includes/class-form-entry.php
@@ -142,7 +142,7 @@ class WeForms_Form_Entry {
                     $this->raw_fields[ $result->meta_key ]['value'] = $value;
 
                     if ( $field['type'] == 'textarea_field' ) {
-                        $value = weforms_format_text( $value );
+                        $value = wp_kses_post( weforms_format_text( $value ) );
                     } elseif ( $field['type'] == 'name_field' ) {
                         $value = implode( ' ', explode( WeForms::$field_separator, $value ) );
                     } elseif ( in_array( $field['type'], [ 'dropdown_field', 'radio_field' ] ) ) {
@@ -180,16 +180,16 @@ class WeForms_Form_Entry {
                                 if ( $field['type'] == 'image_upload' ) {
                                     $thumb = wp_get_attachment_image( $attachment_id, 'thumbnail' );
                                 } else {
-                                    $thumb = get_post_field( 'post_title', $attachment_id );
+                                    $thumb = esc_html( get_post_field( 'post_title', $attachment_id ) );
                                 }
 
-                                $full_size = wp_get_attachment_url( $attachment_id );
+                                $full_size = esc_url( wp_get_attachment_url( $attachment_id ) );
 
                                 $file_field .= sprintf( '<a href="%s" target="_blank">%s</a> ', $full_size, $thumb );
                             }
                         }
 
-                        $value = $file_field;
+                        $value = wp_kses_post( $file_field );
                     } elseif ( $field['type'] == 'google_map' ) {
                         list( $address, $lat, $long ) = explode( '||', $value );
 
@@ -251,7 +251,7 @@ class WeForms_Form_Entry {
                                             <div class="wpufTableHead">&nbsp;</div>';
 
                                 foreach ( $field['grid_columns'] as $column ) {
-                                    $return .= '<div class="wpufTableHead">' . $column . '</div>';
+                                    $return .= '<div class="wpufTableHead">' . esc_html( $column ) . '</div>';
                                 }
 
                                 $return .= '</div>
@@ -260,7 +260,7 @@ class WeForms_Form_Entry {
 
                                 foreach ( $field['grid_rows'] as $row_key => $row_value ) {
                                     $return .= '<div class="wpufTableRow">
-                                                <div class="wpufTableHead">' . $row_value . '</div>';
+                                                <div class="wpufTableHead">' . esc_html( $row_value ) . '</div>';
 
                                     foreach ( $field['grid_columns'] as $column_key => $column_value ) {
                                         if ( isset( $new_val[ $row_key ] ) ) {
@@ -317,7 +317,7 @@ class WeForms_Form_Entry {
                                             <div class="wpufTableHead">&nbsp;</div>';
 
                                 foreach ( $field['grid_columns'] as $column ) {
-                                    $return .= '<div class="wpufTableHead">' . $column . '</div>';
+                                    $return .= '<div class="wpufTableHead">' . esc_html( $column ) . '</div>';
                                 }
 
                                 $return .= '</div>
@@ -326,7 +326,7 @@ class WeForms_Form_Entry {
 
                                 foreach ( $field['grid_rows'] as $row_key => $row_value ) {
                                     $return .= '<div class="wpufTableRow">
-                                                <div class="wpufTableHead">' . $row_value . '</div>';
+                                                <div class="wpufTableHead">' . esc_html( $row_value ) . '</div>';
 
                                     foreach ( $field['grid_columns'] as $column_key => $column_value ) {
                                         if ( isset( $new_val[ $row_key ] ) ) {
@@ -373,16 +373,15 @@ class WeForms_Form_Entry {
                             $value = implode( '<br> ', $serialized_value );
                         }
                     } elseif ( $field['type'] == 'signature_field' ) {
-                        $url   =  $value;
-
                         if ( isset( $_REQUEST['action'] ) != 'weforms_pdf_download' ) {
-                            $url   = content_url() . '/' . $value;
+                            $url   = esc_url( content_url() . '/' . $value );
                             $value = sprintf( '<img src="%s">', $url );
                             $value .= sprintf( '<a style="margin-left: -200px" href="%s">Download</a>', $url );
-                        }
-                        else{
+                        } else {
+                            $url   = esc_url( $value );
                             $value = sprintf( '<img src="%s">', $url );
                         }
+                        $value = wp_kses_post( $value );
                     }
 
                     $this->fields[ $result->meta_key ]['value'] = apply_filters( 'weforms_entry_meta_field', $value, $field );

--- a/includes/class-form-entry.php
+++ b/includes/class-form-entry.php
@@ -185,7 +185,7 @@ class WeForms_Form_Entry {
 
                                 $full_size = esc_url( wp_get_attachment_url( $attachment_id ) );
 
-                                $file_field .= sprintf( '<a href="%s" target="_blank">%s</a> ', $full_size, $thumb );
+                                $file_field .= sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a> ', $full_size, $thumb );
                             }
                         }
 
@@ -221,7 +221,7 @@ class WeForms_Form_Entry {
                                 }
                             }
 
-                            $value = implode( '<br> <br> ', $serialized_value );
+                            $value = wp_kses_post( implode( '<br> <br> ', $serialized_value ) );
                         }
                     } elseif ( $field['type'] == 'checkbox_grid' ) {
                         // Security fix: Prevent PHP Object Injection by restricting allowed classes
@@ -287,7 +287,7 @@ class WeForms_Form_Entry {
                                 </div>';
                             }
 
-                            $value = $return;
+                            $value = wp_kses_post( $return );
                         }
                     } elseif ( $field['type'] == 'multiple_choice_grid' ) {
                         // Security fix: Prevent PHP Object Injection by restricting allowed classes
@@ -353,7 +353,7 @@ class WeForms_Form_Entry {
                                 </div>';
                             }
 
-                            $value = $return;
+                            $value = wp_kses_post( $return );
                         }
                     } elseif ( $field['type'] == 'address_field' || is_serialized( $value ) ) {
                         // Security fix: Prevent PHP Object Injection by restricting allowed classes
@@ -373,7 +373,7 @@ class WeForms_Form_Entry {
                             $value = implode( '<br> ', $serialized_value );
                         }
                     } elseif ( $field['type'] == 'signature_field' ) {
-                        if ( isset( $_REQUEST['action'] ) != 'weforms_pdf_download' ) {
+                        if ( ! isset( $_REQUEST['action'] ) || $_REQUEST['action'] !== 'weforms_pdf_download' ) {
                             $url   = esc_url( content_url() . '/' . $value );
                             $value = sprintf( '<img src="%s">', $url );
                             $value .= sprintf( '<a style="margin-left: -200px" href="%s">Download</a>', $url );

--- a/includes/class-form-entry.php
+++ b/includes/class-form-entry.php
@@ -108,6 +108,22 @@ class WeForms_Form_Entry {
         $grid_css_added = false;
         $grid_css       = '<style>.wpufTable {display: table; width: 100%; } .wpufTableRow {display: table-row; } .wpufTableRow:nth-child(even) {background-color: #f5f5f5; } .wpufTableHeading {background-color: #eee; display: table-header-group; font-weight: bold; } .wpufTableCell, .wpufTableHead {border: none; display: table-cell; padding: 3px 10px; } .wpufTableFoot {background-color: #eee; display: table-footer-group; font-weight: bold; } .wpufTableBody {display: table-row-group; }</style>';
 
+        // Custom allowlist for grid field HTML: wp_kses_post() strips <style> and <input>,
+        // but all dynamic values are already escaped (esc_html/esc_attr) at construction time.
+        $grid_kses_allowed = array(
+            'style' => array(),
+            'div'   => array( 'class' => true ),
+            'label' => array( 'class' => true ),
+            'input' => array(
+                'name'     => true,
+                'class'    => true,
+                'type'     => true,
+                'value'    => true,
+                'checked'  => true,
+                'disabled' => true,
+            ),
+        );
+
         $values = [];
 
         $query = $wpdb->prepare(
@@ -287,7 +303,7 @@ class WeForms_Form_Entry {
                                 </div>';
                             }
 
-                            $value = wp_kses_post( $return );
+                            $value = wp_kses( $return, $grid_kses_allowed );
                         }
                     } elseif ( $field['type'] == 'multiple_choice_grid' ) {
                         // Security fix: Prevent PHP Object Injection by restricting allowed classes
@@ -353,7 +369,7 @@ class WeForms_Form_Entry {
                                 </div>';
                             }
 
-                            $value = wp_kses_post( $return );
+                            $value = wp_kses( $return, $grid_kses_allowed );
                         }
                     } elseif ( $field['type'] == 'address_field' || is_serialized( $value ) ) {
                         // Security fix: Prevent PHP Object Injection by restricting allowed classes

--- a/includes/class-form.php
+++ b/includes/class-form.php
@@ -433,7 +433,6 @@ class WeForms_Form {
     public function get_changed_fields( $form_fields ) {
         $changed_fields = array();
         foreach ( $form_fields as $field ) {
-            $org_field = $field['original_name'];
             // All form fields should have an original name.
             if ( empty( $field['original_name'] ) ) {
                 continue;

--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -615,17 +615,10 @@ class WeForms_Notification {
         foreach ( $matches[1] as $index => $meta_key ) {
             $meta_value = weforms_get_entry_meta( $entry_id, $meta_key, true );
 
-            $files = [];
+            $files       = [];
+            $attachments = is_array( $meta_value ) ? $meta_value : array( $meta_value );
 
-            if ( is_array( $meta_value ) ) {
-                foreach ( $meta_value as $key => $attachment_id ) {
-                    $file_url = wp_get_attachment_url( $attachment_id );
-
-                    if ( $file_url ) {
-                        $files[] = $file_url;
-                    }
-                }
-            } else {
+            foreach ( $attachments as $attachment_id ) {
                 $file_url = wp_get_attachment_url( $attachment_id );
 
                 if ( $file_url ) {

--- a/includes/class-notification.php
+++ b/includes/class-notification.php
@@ -602,6 +602,7 @@ class WeForms_Notification {
      * @return string
      */
     public static function replace_file_tags( $text, $entry_id ) {
+        $text    = $text ?? '';
         $pattern = '/{(?:image|file):(\w*)}/';
 
         preg_match_all( $pattern, $text, $matches );

--- a/includes/fields/class-abstract-fields.php
+++ b/includes/fields/class-abstract-fields.php
@@ -539,11 +539,16 @@ abstract class WeForms_Field_Contract {
             wp_send_json_error( __( 'Unauthorized operation', 'weforms' ) );
         }
 
-        $args  = ! empty( $args ) ? $args : weforms_clean( $_POST );
-        $value = !empty( $args[$field['name']] ) ? $args[$field['name']] : '';
+        if ( $args instanceof WP_REST_Request ) {
+            $args = weforms_clean( $args->get_params() );
+        } elseif ( empty( $args ) ) {
+            $args = weforms_clean( $_POST );
+        }
+
+        $value = ! empty( $args[ $field['name'] ] ) ? $args[ $field['name'] ] : '';
 
         if ( is_array( $value ) ) {
-            $entry_value = implode( WeForms::$field_separator, $args[$field['name']] );
+            $entry_value = implode( WeForms::$field_separator, $value );
         } else {
             $entry_value = sanitize_textarea_field( trim( $value ) );
         }

--- a/includes/fields/class-abstract-fields.php
+++ b/includes/fields/class-abstract-fields.php
@@ -545,7 +545,7 @@ abstract class WeForms_Field_Contract {
         if ( is_array( $value ) ) {
             $entry_value = implode( WeForms::$field_separator, $args[$field['name']] );
         } else {
-            $entry_value = trim( $value  );
+            $entry_value = sanitize_textarea_field( trim( $value ) );
         }
 
         return $entry_value;

--- a/includes/fields/class-abstract-fields.php
+++ b/includes/fields/class-abstract-fields.php
@@ -531,11 +531,17 @@ abstract class WeForms_Field_Contract {
      * @return mixed
      */
     public function prepare_entry( $field, $args = [] ) {
-        if( empty( $_POST['_wpnonce'] ) ) {
-             wp_send_json_error( __( 'Unauthorized operation', 'weforms' ) );
+        if ( $args instanceof WP_REST_Request ) {
+            $nonce = $args->get_param( '_wpnonce' );
+        } else {
+            $nonce = isset( $_POST['_wpnonce'] ) ? $_POST['_wpnonce'] : '';
         }
 
-        if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'wpuf_form_add' ) ) {
+        if ( empty( $nonce ) ) {
+            wp_send_json_error( __( 'Unauthorized operation', 'weforms' ) );
+        }
+
+        if ( ! wp_verify_nonce( sanitize_text_field( wp_unslash( $nonce ) ), 'wpuf_form_add' ) ) {
             wp_send_json_error( __( 'Unauthorized operation', 'weforms' ) );
         }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -621,7 +621,7 @@ function weforms_get_form_field_labels( $form_id ) {
         }
 
         $data[ $field['name'] ] = [
-            'label' => $field['label'],
+            'label' => $field['label'] ?? '',
             'type'  => $field['template'],
         ];
     }
@@ -715,6 +715,7 @@ function weforms_get_browser() {
     $bname    = 'Unknown';
     $platform = 'Unknown';
     $version  = '';
+    $ub       = '';
 
     // first get the platform
     if ( preg_match( '/linux/i', $u_agent ) ) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "weForms",
   "author": "BoldGrid",
-  "version": "1.6.27",
+  "version": "1.6.28",
   "license": "GPL-2.0",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: form builder, contact form, forms, form creator, custom form
 Requires at least: 5.0
 Requires PHP: 7.2.5
 Tested up to: 6.9
-Stable tag: 1.6.27
+Stable tag: 1.6.28
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -239,6 +239,12 @@ Please report security bugs found in the source code of the undefined plugin thr
 17. Event registration form displayed on the site
 
 == Changelog ==
+
+= Version 1.6.28 ( 27 February, 2026 ) =
+* Security: Patched stored XSS vulnerability in form entry fields.
+
+= Version 1.6.27 ( 09 February, 2026 ) =
+* Security: Patched object injection vulnerability.
 
 = Version 1.6.26 ( 17 December, 2025 ) =
 * Fix: Added extra validation for form uploads.

--- a/weforms.php
+++ b/weforms.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://weformspro.com/
  * Author: weForms
  * Author URI: https://weformspro.com/
- * Version: 1.6.27
+ * Version: 1.6.28
  * License: GPL2 or later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: weforms
@@ -55,7 +55,7 @@ final class WeForms {
      *
      * @var string
      */
-    public $version = '1.6.27';
+    public $version = '1.6.28';
 
     /**
      * Form field value seperator


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG7-1407

Manual Testing Guide

  Prerequisites

  1. A WordPress install with weForms active
  2. A weForms form containing a Hidden Field (note its meta
  key name)
  3. A page with the form shortcode (e.g. [weforms id="172"])
  4. A Subscriber-level user account with an Application
  Password (WP Admin → Users → Edit User → Application
  Passwords)
  5. Note the form ID and page ID

  ---
  Step 1 — Get a WPUF nonce
```
curl -s -u 'SUBSCRIBER_USER:APP_PASSWORD' "https://yoursite.com/wp-json/wp/v2/pages/PAGE_ID"  | grep -o 'value="[a-f0-9]*"' | head -1
```

  Copy the nonce value from the output.

  ---
  Step 2 — Submit an XSS payload via REST API
```
curl -s -X POST -u 'SUBSCRIBER_USER:APP_PASSWORD' -d '_wpnonce=NONCE&hidden_test=%22%3E%3Cimg+src%3Dx+onerror%3Dalert%28document.cookie%29%3E&name%5Bfirst%5D=Test&name%5Blast%5D=User&email=test%40test.com&message=test+message&form_id=FORM_ID' "https://yoursite.com/wp-json/weforms/v1/forms/FORM_ID/entries/"
```

  Expected response (patched): the hidden_test value in the
  response data should be ">" — the <img> tag stripped.

  Expected response (unpatched): the full payload "><img
  src=x onerror=alert(document.cookie)> appears unsanitized.

  ---
  Step 3 — Verify no XSS in the entries list

  Log in as admin and navigate to weForms → (your form) →
  Entries.

  - Patched: no alert() dialog; hidden field column shows ">
  as plain text
  - Unpatched: alert() fires on page load

  ---
  Step 4 — Verify no XSS in the entry detail view

  Click Details on the entry submitted in Step 2.

  - Patched: hidden field value shows as escaped text ">; no
  dialog
  - Unpatched: alert() fires

  ---
  Step 5 — Verify textarea display is unaffected

  Submit a normal entry through the front-end form (or via
  the same curl command with a clean message value). Open the
   entry detail view.

  - Patched: the Message field renders its content normally
  (paragraph-wrapped text displays as formatted text, not as
  escaped &lt;p&gt; tags)

  ---
  Step 6 — Verify normal hidden field values are unaffected

  Submit with a clean hidden field value:
```
curl -s -X POST -u 'SUBSCRIBER_USER:APP_PASSWORD' -d '_wpnonce=NONCE&hidden_test=my-tracking-value&name%5Bfirst%5D=Test&name%5Blast%5D=User&email=test%40test.com&message=test+message&form_id=FORM_ID' "https://yoursite.com/wp-json/weforms/v1/forms/FORM_ID/entries/"
```

  Expected: hidden_test stored and displayed as
  my-tracking-value with no truncation or mangling.